### PR TITLE
Back port from OpenJDK 12, fixing JDK-8213583: Error while opening the JFileChooser when desktop contains shortcuts pointing to deleted files.

### DIFF
--- a/src/jdk/src/windows/native/sun/windows/ShellFolder2.cpp
+++ b/src/jdk/src/windows/native/sun/windows/ShellFolder2.cpp
@@ -692,7 +692,7 @@ JNIEXPORT jlong JNICALL Java_sun_awt_shell_Win32ShellFolder2_getLinkLocation
             hres = ppf->Load(wstr, STGM_READ);
             if (SUCCEEDED(hres)) {
                 if (resolve) {
-                    hres = psl->Resolve(NULL, 0);
+                    hres = psl->Resolve(NULL, SLR_NO_UI);
                     // Ignore failure
                 }
                 pidl = (LPITEMIDLIST)NULL;


### PR DESCRIPTION
### Description
This is a backport of https://bugs.openjdk.java.net/browse/JDK-8213583

#### Original description:
If a Windows Desktop shortcut is bad (the file to which it points is gone), regardless of the default directory set in JFilechooser, an error is thrown saying that the shortcut is bad even though JFilechooser was not instructed to look at the Desktop.

### Related issues
The following PullRequests correspond to fixes that are in the same BPR:
#71
#73

### Motivation and context
Java SE 8u202 b32 BPR includes three backports from OpenJDK12. This is one of them.

### Additional context
Original patch:
https://hg.openjdk.java.net/jdk/jdk12/rev/c8071863df80

The patch was applied without issues 