### PR TITLE
Back port from OpenJDK 12, fixing JDK-8207070: Webstart app popup on wrong screen in a one-screen setup changing to multi-monitor.

### DIFF
--- a/src/jdk/src/windows/classes/sun/awt/windows/WWindowPeer.java
+++ b/src/jdk/src/windows/classes/sun/awt/windows/WWindowPeer.java
@@ -474,13 +474,7 @@ public class WWindowPeer extends WPanelPeer implements WindowPeer,
      * Called from native code when we have been dragged onto another screen.
      */
     void draggedToNewScreen() {
-        SunToolkit.executeOnEventHandlerThread((Component)target,new Runnable()
-        {
-            @Override
-            public void run() {
-                displayChanged();
-            }
-        });
+        displayChanged();
     }
 
     public void updateGC() {
@@ -539,7 +533,7 @@ public class WWindowPeer extends WPanelPeer implements WindowPeer,
      */
     @Override
     public void displayChanged() {
-        updateGC();
+        SunToolkit.executeOnEventHandlerThread(target, this::updateGC);
     }
 
     /**

--- a/src/jdk/test/java/awt/Toolkit/DisplayChangesException/DisplayChangesException.java
+++ b/src/jdk/test/java/awt/Toolkit/DisplayChangesException/DisplayChangesException.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.EventQueue;
+import java.awt.GraphicsEnvironment;
+import java.awt.Toolkit;
+import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+
+import sun.awt.DisplayChangedListener;
+import sun.awt.SunToolkit;
+
+/**
+ * @test
+ * @key headful
+ * @bug 8207070
+ * @modules java.desktop/sun.java2d
+ *          java.desktop/sun.awt
+ */
+public final class DisplayChangesException {
+
+    private static boolean fail;
+    private static CountDownLatch go = new CountDownLatch(1);
+
+    static final class TestThread extends Thread {
+
+        private JFrame frame;
+
+        private TestThread(ThreadGroup tg, String threadName) {
+            super(tg, threadName);
+        }
+
+        public void run() {
+            try {
+                test();
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private void test() throws Exception {
+            SunToolkit.createNewAppContext();
+            EventQueue.invokeAndWait(() -> {
+                frame = new JFrame();
+                final JButton b = new JButton();
+                b.addPropertyChangeListener(evt -> {
+                    if (!SunToolkit.isDispatchThreadForAppContext(b)) {
+                        System.err.println("Wrong thread:" + currentThread());
+                        fail = true;
+                    }
+                });
+                frame.add(b);
+                frame.setSize(100, 100);
+                frame.setLocationRelativeTo(null);
+                frame.pack();
+            });
+            go.await();
+            EventQueue.invokeAndWait(() -> {
+                frame.dispose();
+            });
+        }
+    }
+
+    public static void main(final String[] args) throws Exception {
+        ThreadGroup tg0 = new ThreadGroup("ThreadGroup0");
+        ThreadGroup tg1 = new ThreadGroup("ThreadGroup1");
+
+        TestThread t0 = new TestThread(tg0, "TestThread 0");
+        TestThread t1 = new TestThread(tg1, "TestThread 1");
+
+        t0.start();
+        t1.start();
+        Thread.sleep(1500); // Cannot use Robot.waitForIdle
+        testToolkit();
+        Thread.sleep(1500);
+        testGE();
+        Thread.sleep(1500);
+        go.countDown();
+
+        if (fail) {
+            throw new RuntimeException();
+        }
+    }
+
+    private static void testGE() {
+        Object ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        if (!(ge instanceof DisplayChangedListener)) {
+            return;
+        }
+        ((DisplayChangedListener) ge).displayChanged();
+    }
+
+    private static void testToolkit() {
+        final Class toolkit;
+        try {
+            toolkit = Class.forName("sun.awt.windows.WToolkit");
+        } catch (final ClassNotFoundException ignored) {
+            return;
+        }
+        try {
+            final Method displayChanged = toolkit.getMethod("displayChanged");
+            displayChanged.invoke(Toolkit.getDefaultToolkit());
+        } catch (final Exception e) {
+            e.printStackTrace();
+            fail = true;
+        }
+    }
+}
+


### PR DESCRIPTION
### Description
This is a backport of https://bugs.openjdk.java.net/browse/JDK-8207070

#### Original description:
Issue with webstart app where the popup menu appear on a wrong screen
on an initial one-screen setup and it changes to multi-monitor.
The popup is displayed on wrong screen.

The issue does not happen with this same application when it is launched
locally (not via webstart).

### Related issues
The following PullRequests correspond to fixes that are in the same BPR:
https://github.com/corretto/corretto-8/pull/70
https://github.com/corretto/corretto-8/pull/73

### Motivation and context
Java SE 8u202 b32 BPR includes three backports from OpenJDK12. This is one of them.

### Additional context
Original patch:
https://hg.openjdk.java.net/jdk/jdk12/rev/6cf31480d3a3

Patch had to be split into multiple smaller files before applying due to relative file locations change.
Changes on file src/jdk/src/windows/classes/sun/awt/windows/WToolkit.java had to be done manually, as function displayChanged had diverged too much.