### PR TITLE
Back port from OpenJDK 12, fixing JDK-8027434: "-XX:OnOutOfMemoryError" uses fork instead of vfork

### DIFF
--- a/src/hotspot/src/os/aix/vm/os_aix.cpp
+++ b/src/hotspot/src/os/aix/vm/os_aix.cpp
@@ -5142,7 +5142,7 @@ extern char** environ;
 // or -1 on failure (e.g. can't fork a new process).
 // Unlike system(), this function can be called from signal handler. It
 // doesn't block SIGINT et al.
-int os::fork_and_exec(char* cmd) {
+int os::fork_and_exec(char* cmd, bool use_vfork_if_available) {
   char * argv[4] = {"sh", "-c", cmd, NULL};
 
   pid_t pid = fork();

--- a/src/hotspot/src/os/bsd/vm/os_bsd.cpp
+++ b/src/hotspot/src/os/bsd/vm/os_bsd.cpp
@@ -4716,7 +4716,7 @@ extern char** environ;
 // or -1 on failure (e.g. can't fork a new process).
 // Unlike system(), this function can be called from signal handler. It
 // doesn't block SIGINT et al.
-int os::fork_and_exec(char* cmd) {
+int os::fork_and_exec(char* cmd, bool use_vfork_if_available) {
   const char * argv[4] = {"sh", "-c", cmd, NULL};
 
   // fork() in BsdThreads/NPTL is not async-safe. It needs to run

--- a/src/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/src/hotspot/src/os/linux/vm/os_linux.cpp
@@ -6357,10 +6357,16 @@ extern char** environ;
 // or -1 on failure (e.g. can't fork a new process).
 // Unlike system(), this function can be called from signal handler. It
 // doesn't block SIGINT et al.
-int os::fork_and_exec(char* cmd) {
+int os::fork_and_exec(char* cmd, bool use_vfork_if_available) {
   const char * argv[4] = {"sh", "-c", cmd, NULL};
 
-  pid_t pid = fork();
+  pid_t pid ;
+
+  if (use_vfork_if_available) {
+    pid = vfork();
+  } else {
+    pid = fork();
+  }
 
   if (pid < 0) {
     // fork failed

--- a/src/hotspot/src/os/solaris/vm/os_solaris.cpp
+++ b/src/hotspot/src/os/solaris/vm/os_solaris.cpp
@@ -6153,7 +6153,7 @@ extern char** environ;
 // or -1 on failure (e.g. can't fork a new process).
 // Unlike system(), this function can be called from signal handler. It
 // doesn't block SIGINT et al.
-int os::fork_and_exec(char* cmd) {
+int os::fork_and_exec(char* cmd, bool use_vfork_if_available) {
   char * argv[4];
   argv[0] = (char *)"sh";
   argv[1] = (char *)"-c";

--- a/src/hotspot/src/os/windows/vm/os_windows.cpp
+++ b/src/hotspot/src/os/windows/vm/os_windows.cpp
@@ -5034,7 +5034,7 @@ void Parker::unpark() {
 
 // Run the specified command in a separate process. Return its exit value,
 // or -1 on failure (e.g. can't create a new process).
-int os::fork_and_exec(char* cmd) {
+int os::fork_and_exec(char* cmd, bool use_vfork_if_available) {
   STARTUPINFO si;
   PROCESS_INFORMATION pi;
 

--- a/src/hotspot/src/share/vm/runtime/os.hpp
+++ b/src/hotspot/src/share/vm/runtime/os.hpp
@@ -527,7 +527,7 @@ class os: AllStatic {
   static char* do_you_want_to_debug(const char* message);
 
   // run cmd in a separate process and return its exit code; or -1 on failures
-  static int fork_and_exec(char *cmd);
+  static int fork_and_exec(char *cmd, bool use_vfork_if_available = false);
 
   // os::exit() is merged with vm_exit()
   // static void exit(int num);

--- a/src/hotspot/src/share/vm/utilities/vmError.cpp
+++ b/src/hotspot/src/share/vm/utilities/vmError.cpp
@@ -1147,7 +1147,7 @@ void VM_ReportJavaOutOfMemory::doit() {
 #endif
     tty->print_cr("\"%s\"...", cmd);
 
-    if (os::fork_and_exec(cmd) < 0) {
+    if (os::fork_and_exec(cmd, true) < 0) {
       tty->print_cr("os::fork_and_exec failed: %s (%d)", strerror(errno), errno);
     }
   }


### PR DESCRIPTION
### Description
This is a backport of https://bugs.openjdk.java.net/browse/JDK-8027434

#### Original description:
When calling fork/exec the process is duplicated by fork and only then the new copy is replaced using exec. That leads to problems when the JVM uses most of the memory and only a small program is to be started. 

The problem was solved for Process.start in 2009, but was apparently not solved for execution of the "-XX:OnOutOfMemoryError" handler. 

-XX:OnOutOfMemoryError=reboot did not work, even though the log showed it would be started. Looking in the openJDK 7u40 sources, I found that this code still uses fork/exec instead of vfork, which was the solution for the Process.start case.... 

### Related issues
The following PullRequests correspond to fixes that are in the same BPR:
#70 
#71 

### Motivation and context
Java SE 8u202 b32 BPR includes three backports from OpenJDK12. This is one of them.

### Additional context
Original patch:
https://hg.openjdk.java.net/jdk/jdk12/rev/101c2b6eacbe

Patch required manually modification of the file paths. Change on src/hotspot/src/share/vm/utilities/vmError.cpp was done manually.