### PR TITLE
Add missing declaration to backport of JDK-8207070

### DIFF
--- a/src/jdk/src/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/jdk/src/windows/classes/sun/awt/windows/WToolkit.java
@@ -830,6 +830,8 @@ public final class WToolkit extends SunToolkit implements Runnable {
         .paletteChanged();
     }
 
+    private static ExecutorService displayChangeExecutor;
+
     /*
      * Called from Toolkit native code when a WM_DISPLAYCHANGE occurs.
      * Have Win32GraphicsEnvironment execute the display change code on the


### PR DESCRIPTION
### Description
There is a missing declaration on WToolkit.java breaking windows builds.

### Related issues
https://github.com/corretto/corretto-8/pull/71/files
