### PR TITLE
Include /jre/lib/applet directory in rpm and deb packaging

### DIFF
--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -109,6 +109,7 @@ task generateJdkDeb(type: Deb) {
 
     from(jdkBinaryDir) {
         into jdkHome
+        createDirectoryEntry = true
     }
 }
 

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -109,6 +109,7 @@ task generateJdkRpm(type: Rpm) {
 
     from(jdkBinaryDir) {
         into jdkHome
+        createDirectoryEntry = true
     }
 }
 


### PR DESCRIPTION
`/jre/lib/applet` directory is missing in Corretto8 generic Linux deb and rpm, which makes it inconsistent with generic Linux tgz and other artifacts. This patch adds it back to deb and rpm. 
