### PR TITLE
Add jinfo file to Debian package

### DIFF
--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright (c) 2019, Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,12 @@ def jdkInstallationDirName = "java-1.${project.version.major}.0-amazon-corretto"
 def jdkHome = "${jvmDir}/${jdkInstallationDirName}".toString()
 def jdkBinaryDir = "${buildRoot}/amazon-corretto-${project.version.full}-linux-x64"
 def jdkPackageName = "java-1.${project.version.major}.0-amazon-corretto-jdk"
+
+// In trusty repo, openjdk7 has priority 1071 and openjdk6 has 1061
+// Corretto uses the same priority in both rpm and deb
+def alternativesPriority = "10${project.version.major}00${project.version.update}".toString()
+
+def jinfoName = ".${jdkInstallationDirName}.jinfo"
 
 ospackage {
     // Valid version must start with a digit and only contain [A-Za-z0-9.+:~-]
@@ -70,18 +76,32 @@ task extractUniversalTar(type: Copy) {
  * Create script copies under build root scripts folder.
  */
 task inflateDebScriptTemplate(type: Copy) {
-    dependsOn extractUniversalTar 
-    // In trusty repo, openjdk7 has priority 1071 and openjdk6 has 1061
-    // Corretto uses the same priority in both rpm and deb
-    def priority = "10${project.version.major}00${project.version.update}".toString()
+    dependsOn extractUniversalTar
     from('scripts') {
         include '**/*.template'
         rename { file -> file.replace('.template', '') }
         filter(org.apache.tools.ant.filters.ReplaceTokens,
-                tokens: project.version + [java_home: jdkHome, alternatives_priority: priority,
+                tokens: project.version + [java_home: jdkHome, alternatives_priority: alternativesPriority,
                                            jdk_tools: jdkTools.join(' '), jre_tools: jreTools.join(' ')])
     }
     into "${buildRoot}/scripts"
+}
+
+/**
+ * Inflate jinfo file used by update-java-alternatives command.
+ * Create script copy under buildRoot/jinfo folder. See
+ * http://manpages.ubuntu.com/manpages/xenial/man8/update-java-alternatives.8.html#files
+ */
+task inflateJinfoTemplate(type: Copy) {
+    from('jinfo') {
+        include '**/*.template'
+        rename ( 'jinfo.template', jinfoName )
+        filter(org.apache.tools.ant.filters.ReplaceTokens,
+                tokens: project.version + [java_home: jdkHome, alternatives_priority: alternativesPriority,
+                                           directory_name: jdkInstallationDirName.toString()])
+        expand(jre_tools: jreTools, jdk_tools: jdkTools)
+    }
+    into "${buildRoot}/jinfo"
 }
 
 /**
@@ -91,6 +111,7 @@ task inflateDebScriptTemplate(type: Copy) {
 task generateJdkDeb(type: Deb) {
     description 'Create the DEB package for Corretto JDK'
     dependsOn inflateDebScriptTemplate
+    dependsOn inflateJinfoTemplate
 
     packageName jdkPackageName
     packageDescription "Amazon Corretto\'s packaging of the OpenJDK ${project.version.major} code."
@@ -110,6 +131,11 @@ task generateJdkDeb(type: Deb) {
     from(jdkBinaryDir) {
         into jdkHome
         createDirectoryEntry = true
+    }
+
+    from("$buildRoot/jinfo") {
+        include '**/*.jinfo'
+        into jvmDir
     }
 }
 

--- a/installers/linux/universal/deb/jinfo/jinfo.template
+++ b/installers/linux/universal/deb/jinfo/jinfo.template
@@ -1,0 +1,9 @@
+name=@directory_name@
+alias=@directory_name@
+priority=@alternatives_priority@
+section=main
+
+<% jre_tools.each {%>jre ${it} @java_home@/jre/bin/${it}
+<%}%>
+<% jdk_tools.each {%>jdk ${it} @java_home@/bin/${it}
+<%}%>

--- a/installers/linux/universal/test/docker/deb/run_test.sh
+++ b/installers/linux/universal/test/docker/deb/run_test.sh
@@ -63,6 +63,18 @@ function test_alternatives_after_installation() {
     fi
 }
 
+# Examine Corretto shows up in update_java_alternatives command
+# correctly and is switchable.
+function test_update_java_alternatives_after_installation() {
+    update-java-alternatives -s ${jdkInstallationDirectoryName} &> /dev/null
+    if [[ $? != 0 ]]; then
+        echo "[DEB Test] FAILED: test_update_java_alternatives_after_installation"
+        status=1
+    else
+        echo "[DEB Test] PASSED: test_update_java_alternatives_after_installation"
+    fi
+}
+
 function test_jdk_uninstallation() {
     dpkg -r ${simpleJdkPackageName} &> /dev/null
     if [[ $? != 0 ]]; then
@@ -100,6 +112,18 @@ function test_alternatives_after_uninstallation() {
     fi
 }
 
+function test_update_java_alternatives_after_uninstallation() {
+    # Corretto entry is expected to be removed from update-java-alternatives list
+    # after uninstallation.
+    update-java-alternatives -l | grep ${jdkInstallationDirectoryName} &> /dev/null
+    if [[ $? == 0 ]]; then
+        echo "[DEB Test] FAILED: test_update_java_alternatives_after_uninstallation"
+        status=1
+    else
+        echo "[DEB Test] PASSED: test_update_java_alternatives_after_uninstallation"
+    fi
+}
+
 # Delay test execution to make sure Gradle console
 # log output looks correct.
 sleep 5
@@ -107,8 +131,10 @@ sleep 5
 test_jdk_installation
 test_alternatives_after_installation "jdk"
 test_alternatives_after_installation "jre"
+test_update_java_alternatives_after_installation
 test_jdk_uninstallation
 test_alternatives_after_uninstallation "jdk"
 test_alternatives_after_uninstallation "jre"
+test_update_java_alternatives_after_uninstallation
 
 exit ${status}


### PR DESCRIPTION
Include jinfo file in deb packaging to support 'update-java-alternatives' command.

### Description

When packaging deb package, inflate jinfo template and copy it to `/usr/lib/jvm/` directory. Make it possible to update Corretto alternatives through `update-java-alternatives` command.

Inflated jinfo file example:

```
name=java-1.8.0-amazon-corretto
alias=java-1.8.0-amazon-corretto
priority=10800202
section=main

jre java /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/java
jre jjs /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/jjs
jre keytool /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/keytool
jre orbd /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/orbd
jre pack200 /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/pack200
jre policytool /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/policytool
jre rmid /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/rmid
jre rmiregistry /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/rmiregistry
jre servertool /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/servertool
jre tnameserv /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/tnameserv
jre unpack200 /usr/lib/jvm/java-1.8.0-amazon-corretto/jre/bin/unpack200

jdk javac /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/javac
jdk appletviewer /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/appletviewer
jdk extcheck /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/extcheck
jdk extcheck /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/extcheck
jdk jar /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jar
jdk jarsigner /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jarsigner
jdk java-rmi.cgi /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/java-rmi.cgi
jdk javadoc /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/javadoc
jdk javah /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/javah
jdk javap /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/javap
jdk jcmd /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jcmd
jdk jconsole /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jconsole
jdk jdb /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jdb
jdk jdeps /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jdeps
jdk jhat /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jhat
jdk jinfo /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jinfo
jdk jmap /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jmap
jdk jps /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jps
jdk jrunscript /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jrunscript
jdk jsadebugd /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jsadebugd
jdk jstack /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jstack
jdk jstat /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jstat
jdk jstatd /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/jstatd
jdk native2ascii /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/native2ascii
jdk rmic /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/rmic
jdk schemagen /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/schemagen
jdk serialver /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/serialver
jdk wsgen /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/wsgen
jdk wsimport /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/wsimport
jdk xjc /usr/lib/jvm/java-1.8.0-amazon-corretto/bin/xjc

```


### Related issues

https://github.com/corretto/corretto-8/issues/63


### How has this been tested?

Built deb package with command `./gradlew :installers:linux:universal:deb:build`. Install Corretto deb package and Debian default openjdk on Ububtu 16.04 container.


List java alternatives:

```
# update-java-alternatives  -l
java-1.8.0-amazon-corretto     10800202   /usr/lib/jvm/java-1.8.0-amazon-corretto
java-1.8.0-openjdk-amd64       1081       /usr/lib/jvm/java-1.8.0-openjdk-amd64
```

Switch to Corretto:

```
# update-java-alternatives  -s java-1.8.0-amazon-corretto && java -version
openjdk version "1.8.0_202"
OpenJDK Runtime Environment Corretto-8.202.08.2 (build 1.8.0_202-b08)
OpenJDK 64-Bit Server VM Corretto-8.202.08.2 (build 25.202-b08, mixed mode)
```

Switch to Ubuntu OpenJDK:

```
# update-java-alternatives  -s java-1.8.0-openjdk-amd64 && java -version
openjdk version "1.8.0_191"
OpenJDK Runtime Environment (build 1.8.0_191-8u191-b12-2ubuntu0.16.04.1-b12)
OpenJDK 64-Bit Server VM (build 25.191-b12, mixed mode)
```


- Passed integration tests for deb:

```
# ./gradlew :installers:linux:universal:test:testDeb
...

STDOUT: [DEB Test] PASSED: test_jdk_installation
STDOUT: [DEB Test] PASSED: test_jdk_alternatives_after_installation
STDOUT: [DEB Test] PASSED: test_jre_alternatives_after_installation
STDOUT: [DEB Test] PASSED: test_update_java_alternatives_after_installation
STDOUT: [DEB Test] PASSED: test_jdk_uninstallation
STDOUT: [DEB Test] PASSED: test_jdk_alternatives_after_uninstallation
STDOUT: [DEB Test] PASSED: test_jre_alternatives_after_uninstallation
STDOUT: [DEB Test] PASSED: test_update_java_alternatives_after_uninstallation
```


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
