### PR TITLE
Upgrade aarch64 port to Icedtea3.11.

### DIFF
--- a/src/hotspot/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.hpp
+++ b/src/hotspot/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.hpp
@@ -24,8 +24,8 @@
  *
  */
 
-#ifndef CPU_X86_VM_C1_LIRASSEMBLER_X86_HPP
-#define CPU_X86_VM_C1_LIRASSEMBLER_X86_HPP
+#ifndef CPU_AARCH64_VM_C1_LIRASSEMBLER_AARCH64_HPP
+#define CPU_AARCH64_VM_C1_LIRASSEMBLER_AARCH64_HPP
 
 // ArrayCopyStub needs access to bailout
 friend class ArrayCopyStub;
@@ -65,7 +65,7 @@ friend class ArrayCopyStub;
   struct tableswitch switches[max_tableswitches];
   int tableswitch_count;
 
-  void pd_init() { tableswitch_count = 0; }
+  void init() { tableswitch_count = 0; }
 
   void deoptimize_trap(CodeEmitInfo *info);
 
@@ -80,4 +80,4 @@ enum { call_stub_size = 12 * NativeInstruction::instruction_size,
        deopt_handler_size = 7 * NativeInstruction::instruction_size };
 
 
-#endif // CPU_X86_VM_C1_LIRASSEMBLER_X86_HPP
+#endif // CPU_AARCH64_VM_C1_LIRASSEMBLER_AARCH64_HPP

--- a/src/hotspot/src/cpu/aarch64/vm/globals_aarch64.hpp
+++ b/src/hotspot/src/cpu/aarch64/vm/globals_aarch64.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013, Red Hat Inc.
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates.
+ * Copyright (c) 2000, 2011, Oracle and/or its affiliates.
  * All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -126,7 +126,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Use LSE instructions")                                       \
   product(bool, UseSIMDForMemoryOps, false,                             \
           "Use SIMD instructions in generated memory move code")        \
-  product(bool, AvoidUnalignedAccesses, true,                           \
+  product(bool, AvoidUnalignedAccesses, false,                          \
           "Avoid generating unaligned memory accesses")                 \
   product(bool, UseBlockZeroing, true,                                  \
           "Use DC ZVA for block zeroing")                               \

--- a/src/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.hpp
+++ b/src/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.hpp
@@ -788,6 +788,9 @@ public:
   void store_check_part_2(Register obj);
 
   // oop manipulations
+  // C 'boolean' to Java boolean: x == 0 ? 0 : 1
+  void c2bool(Register x);
+
   void load_klass(Register dst, Register src);
   void store_klass(Register dst, Register src);
   void cmp_klass(Register oop, Register trial_klass, Register tmp);

--- a/src/hotspot/src/cpu/aarch64/vm/methodHandles_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/methodHandles_aarch64.cpp
@@ -103,8 +103,8 @@ void MethodHandles::jump_from_method_handle(MacroAssembler* _masm, Register meth
     // compiled code in threads for which the event is enabled.  Check here for
     // interp_only_mode if these events CAN be enabled.
 
-    __ ldrb(rscratch1, Address(rthread, JavaThread::interp_only_mode_offset()));
-    __ cbnz(rscratch1, run_compiled_code);
+    __ ldrw(rscratch1, Address(rthread, JavaThread::interp_only_mode_offset()));
+    __ cbzw(rscratch1, run_compiled_code);
     __ ldr(rscratch1, Address(method, Method::interpreter_entry_offset()));
     __ br(rscratch1);
     __ BIND(run_compiled_code);

--- a/src/hotspot/src/cpu/aarch64/vm/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/sharedRuntime_aarch64.cpp
@@ -1103,7 +1103,7 @@ static void restore_args(MacroAssembler *masm, int arg_count, int first_arg, VMR
     }
   }
   __ pop(x, sp);
-  for ( int i = first_arg ; i < arg_count ; i++ ) {
+  for ( int i = arg_count - 1 ; i >= first_arg ; i-- ) {
     if (args[i].first()->is_Register()) {
       ;
     } else if (args[i].first()->is_FloatRegister()) {
@@ -1918,7 +1918,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // Unpack native results.
   switch (ret_type) {
-  case T_BOOLEAN: __ ubfx(r0, r0, 0, 8);             break;
+  case T_BOOLEAN: __ c2bool(r0);                     break;
   case T_CHAR   : __ ubfx(r0, r0, 0, 16);            break;
   case T_BYTE   : __ sbfx(r0, r0, 0, 8);             break;
   case T_SHORT  : __ sbfx(r0, r0, 0, 16);            break;

--- a/src/hotspot/src/cpu/aarch64/vm/templateInterpreter_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/templateInterpreter_aarch64.cpp
@@ -285,8 +285,8 @@ address TemplateInterpreterGenerator::generate_result_handler_for(
         BasicType type) {
     address entry = __ pc();
   switch (type) {
-  case T_BOOLEAN: __ uxtb(r0, r0);        break;
-  case T_CHAR   : __ uxth(r0, r0);       break;
+  case T_BOOLEAN: __ c2bool(r0);          break;
+  case T_CHAR   : __ uxth(r0, r0);        break;
   case T_BYTE   : __ sxtb(r0, r0);        break;
   case T_SHORT  : __ sxth(r0, r0);        break;
   case T_INT    : __ uxtw(r0, r0);        break;  // FIXME: We almost certainly don't need this
@@ -1863,6 +1863,7 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   __ restore_locals();
   __ restore_constant_pool_cache();
   __ get_method(rmethod);
+  __ get_dispatch();
 
   // The method data pointer was incremented already during
   // call profiling. We have to restore the mdp for the current bcp.
@@ -1879,8 +1880,8 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
     Label L_done;
 
     __ ldrb(rscratch1, Address(rbcp, 0));
-    __ cmpw(r1, Bytecodes::_invokestatic);
-    __ br(Assembler::EQ, L_done);
+    __ cmpw(rscratch1, Bytecodes::_invokestatic);
+    __ br(Assembler::NE, L_done);
 
     // The member name argument must be restored if _invokestatic is re-executed after a PopFrame call.
     // Detect such a case in the InterpreterRuntime function and return the member name argument, or NULL.
@@ -1916,7 +1917,6 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   // remove the activation (without doing throws on illegalMonitorExceptions)
   __ remove_activation(vtos, false, true, false);
   // restore exception
-  // restore exception
   __ get_vm_result(r0, rthread);
 
   // In between activations - previous activation type unknown yet
@@ -1925,9 +1925,8 @@ void TemplateInterpreterGenerator::generate_throw_exception() {
   //
   // r0: exception
   // lr: return address/pc that threw exception
-  // rsp: expression stack of caller
+  // esp: expression stack of caller
   // rfp: fp of caller
-  // FIXME: There's no point saving LR here because VM calls don't trash it
   __ stp(r0, lr, Address(__ pre(sp, -2 * wordSize)));  // save exception & return address
   __ super_call_VM_leaf(CAST_FROM_FN_PTR(address,
                           SharedRuntime::exception_handler_for_return_address),

--- a/src/hotspot/src/cpu/aarch64/vm/templateTable_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/templateTable_aarch64.cpp
@@ -2633,7 +2633,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static) {
   {
     Label notVolatile;
     __ tbz(r5, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
-    __ membar(MacroAssembler::StoreStore);
+    __ membar(MacroAssembler::StoreStore | MacroAssembler::LoadStore);
     __ bind(notVolatile);
   }
 
@@ -2887,7 +2887,7 @@ void TemplateTable::fast_storefield(TosState state)
   {
     Label notVolatile;
     __ tbz(r3, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
-    __ membar(MacroAssembler::StoreStore);
+    __ membar(MacroAssembler::StoreStore | MacroAssembler::LoadStore);
     __ bind(notVolatile);
   }
 

--- a/src/hotspot/src/cpu/aarch64/vm/vm_version_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/vm_version_aarch64.cpp
@@ -295,12 +295,7 @@ void VM_Version::get_processor_features() {
   if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
     UsePopCountInstruction = true;
   }
-#if 0
-  // This machine allows unaligned memory accesses
-  if (FLAG_IS_DEFAULT(UseUnalignedAccesses)) {
-    FLAG_SET_DEFAULT(UseUnalignedAccesses, true);
-  }
-#endif
+
   if (FLAG_IS_DEFAULT(UseMontgomeryMultiplyIntrinsic)) {
     UseMontgomeryMultiplyIntrinsic = true;
   }

--- a/src/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/src/hotspot/src/os/linux/vm/os_linux.cpp
@@ -724,6 +724,10 @@ static void _expand_stack_to(address bottom) {
   }
 }
 
+void os::Linux::expand_stack_to(address bottom) {
+  _expand_stack_to(bottom);
+}
+
 bool os::Linux::manually_expand_stack(JavaThread * t, address addr) {
   assert(t!=NULL, "just checking");
   assert(t->osthread()->expanding_stack(), "expand should be set");
@@ -1443,9 +1447,9 @@ void os::Linux::fast_thread_clock_init() {
   // must return at least tp.tv_sec == 0 which means a resolution
   // better than 1 sec. This is extra check for reliability.
 
-  if (pthread_getcpuclockid_func &&
-      pthread_getcpuclockid_func(_main_thread, &clockid) == 0 &&
-      sys_clock_getres(clockid, &tp) == 0 && tp.tv_sec == 0) {
+  if(pthread_getcpuclockid_func &&
+     pthread_getcpuclockid_func(_main_thread, &clockid) == 0 &&
+     sys_clock_getres(clockid, &tp) == 0 && tp.tv_sec == 0) {
 
     _supports_fast_thread_cpu_time = true;
     _pthread_getcpuclockid = pthread_getcpuclockid_func;
@@ -1943,7 +1947,7 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen)
   } arch_t;
 
   #ifndef EM_486
-  #define EM_486       6               /* Intel 80486 */
+  #define EM_486     6        // Intel 80486
   #endif
 
   #ifndef EM_AARCH64

--- a/src/hotspot/src/os/linux/vm/os_linux.hpp
+++ b/src/hotspot/src/os/linux/vm/os_linux.hpp
@@ -248,6 +248,8 @@ class Linux {
   // LinuxThreads work-around for 6292965
   static int safe_cond_timedwait(pthread_cond_t *_cond, pthread_mutex_t *_mutex, const struct timespec *_abstime);
 
+  static void expand_stack_to(address bottom);
+
 private:
   typedef int (*sched_getcpu_func_t)(void);
   typedef int (*numa_node_to_cpus_func_t)(int node, unsigned long *buffer, int bufferlen);

--- a/src/hotspot/src/share/vm/adlc/adlparse.cpp
+++ b/src/hotspot/src/share/vm/adlc/adlparse.cpp
@@ -2868,7 +2868,8 @@ void ADLParser::ins_encode_parse_block(InstructForm& inst) {
   const char* param = NULL;
   inst._parameters.reset();
   while ((param = inst._parameters.iter()) != NULL) {
-    OperandForm* opForm = (OperandForm*) inst._localNames[param];
+    OpClassForm* opForm = inst._localNames[param]->is_opclass();
+    assert(opForm != NULL, "sanity");
     encoding->add_parameter(opForm->_ident, param);
   }
 
@@ -3338,7 +3339,8 @@ void ADLParser::constant_parse(InstructForm& inst) {
   const char* param = NULL;
   inst._parameters.reset();
   while ((param = inst._parameters.iter()) != NULL) {
-    OperandForm* opForm = (OperandForm*) inst._localNames[param];
+    OpClassForm* opForm = inst._localNames[param]->is_opclass();
+    assert(opForm != NULL, "sanity");
     encoding->add_parameter(opForm->_ident, param);
   }
 

--- a/src/hotspot/src/share/vm/adlc/dfa.cpp
+++ b/src/hotspot/src/share/vm/adlc/dfa.cpp
@@ -757,10 +757,12 @@ const char *Expr::compute_expr(const Expr *c1, const Expr *c2) {
 }
 
 int Expr::compute_min(const Expr *c1, const Expr *c2) {
-  int result = c1->_min_value + c2->_min_value;
-  assert( result >= 0, "Invalid cost computation");
+  int v1 = c1->_min_value;
+  int v2 = c2->_min_value;
+  assert(0 <= v2 && v2 <= Expr::Max, "sanity");
+  assert(v1 <= Expr::Max - v2, "Invalid cost computation");
 
-  return result;
+  return v1 + v2;
 }
 
 int Expr::compute_max(const Expr *c1, const Expr *c2) {

--- a/src/hotspot/src/share/vm/adlc/formssel.cpp
+++ b/src/hotspot/src/share/vm/adlc/formssel.cpp
@@ -921,7 +921,8 @@ void InstructForm::build_components() {
   const char *name;
   const char *kill_name = NULL;
   for (_parameters.reset(); (name = _parameters.iter()) != NULL;) {
-    OperandForm *opForm = (OperandForm*)_localNames[name];
+    OpClassForm *opForm = _localNames[name]->is_opclass();
+    assert(opForm != NULL, "sanity");
 
     Effect* e = NULL;
     {
@@ -938,7 +939,8 @@ void InstructForm::build_components() {
       // complex so simply enforce the restriction during parse.
       if (kill_name != NULL &&
           e->isa(Component::TEMP) && !e->isa(Component::DEF)) {
-        OperandForm* kill = (OperandForm*)_localNames[kill_name];
+        OpClassForm* kill = _localNames[kill_name]->is_opclass();
+        assert(kill != NULL, "sanity");
         globalAD->syntax_err(_linenum, "%s: %s %s must be at the end of the argument list\n",
                              _ident, kill->_ident, kill_name);
       } else if (e->isa(Component::KILL) && !e->isa(Component::USE)) {
@@ -2340,7 +2342,8 @@ void OperandForm::build_components() {
   // Add parameters that "do not appear in match rule".
   const char *name;
   for (_parameters.reset(); (name = _parameters.iter()) != NULL;) {
-    OperandForm *opForm = (OperandForm*)_localNames[name];
+    OpClassForm *opForm = _localNames[name]->is_opclass();
+    assert(opForm != NULL, "sanity");
 
     if ( _components.operand_position(name) == -1 ) {
       _components.insert(name, opForm->_ident, Component::INVALID, false);

--- a/src/hotspot/src/share/vm/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/src/share/vm/c1/c1_LIRAssembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
 #include "c1/c1_MacroAssembler.hpp"
 #include "c1/c1_ValueStack.hpp"
 #include "ci/ciInstance.hpp"
+#include "runtime/os.hpp"
 #ifdef TARGET_ARCH_x86
 # include "nativeInst_x86.hpp"
 # include "vmreg_x86.inline.hpp"
@@ -129,7 +130,7 @@ LIR_Assembler::LIR_Assembler(Compilation* c):
 {
   _slow_case_stubs = new CodeStubList();
 #ifdef TARGET_ARCH_aarch64
-  pd_init(); // Target-dependent initialization
+  init(); // Target-dependent initialization
 #endif
 }
 
@@ -169,8 +170,10 @@ void LIR_Assembler::emit_stubs(CodeStubList* stub_list) {
     }
 #endif
     s->emit_code(this);
+# ifndef AARCH64
 #ifdef ASSERT
     s->assert_no_unbound_labels();
+#endif
 #endif
   }
 }
@@ -881,7 +884,7 @@ void LIR_Assembler::verify_oop_map(CodeEmitInfo* info) {
           stringStream st;
           st.print("bad oop %s at %d", r->as_Register()->name(), _masm->offset());
 #ifdef SPARC
-          _masm->_verify_oop(r->as_Register(), strdup(st.as_string()), __FILE__, __LINE__);
+          _masm->_verify_oop(r->as_Register(), os::strdup(st.as_string(), mtCompiler), __FILE__, __LINE__);
 #else
           _masm->verify_oop(r->as_Register());
 #endif

--- a/src/hotspot/src/share/vm/memory/metaspace.cpp
+++ b/src/hotspot/src/share/vm/memory/metaspace.cpp
@@ -3046,10 +3046,49 @@ void Metaspace::allocate_metaspace_compressed_klass_ptrs(char* requested_addr, a
   // Don't use large pages for the class space.
   bool large_pages = false;
 
+#ifndef AARCH64
   ReservedSpace metaspace_rs = ReservedSpace(compressed_class_space_size(),
                                              _reserve_alignment,
                                              large_pages,
                                              requested_addr, 0);
+#else // AARCH64
+  ReservedSpace metaspace_rs;
+
+  // Our compressed klass pointers may fit nicely into the lower 32
+  // bits.
+  if ((uint64_t)requested_addr + compressed_class_space_size() < 4*G) {
+    metaspace_rs = ReservedSpace(compressed_class_space_size(),
+                                  _reserve_alignment,
+                                 large_pages,
+                                 requested_addr, 0);
+  }
+  if (!metaspace_rs.is_reserved()) {
+    // Try to align metaspace so that we can decode a compressed klass
+    // with a single MOVK instruction.  We can do this iff the
+    // compressed class base is a multiple of 4G.
+    for (char *a = (char*)align_ptr_up(requested_addr, 4*G);
+      a < (char*)(1024*G);
+      a += 4*G) {
+      if (UseSharedSpaces &&
+          !can_use_cds_with_metaspace_addr(a, cds_base)) {
+        // We failed to find an aligned base that will reach.  Fall
+        // back to using our requested addr.
+        metaspace_rs = ReservedSpace(compressed_class_space_size(),
+                                     _reserve_alignment,
+                                     large_pages,
+                                     requested_addr, 0);
+        break;
+      }
+      metaspace_rs = ReservedSpace(compressed_class_space_size(),
+                                   _reserve_alignment,
+                                   large_pages,
+                                   a, 0);
+      if (metaspace_rs.is_reserved())
+        break;
+    }
+  }
+#endif // AARCH64
+
   if (!metaspace_rs.is_reserved()) {
 #if INCLUDE_CDS
     if (UseSharedSpaces) {

--- a/src/hotspot/src/share/vm/runtime/vframeArray.cpp
+++ b/src/hotspot/src/share/vm/runtime/vframeArray.cpp
@@ -477,7 +477,7 @@ void vframeArray::fill_in(JavaThread* thread,
   // Copy registers for callee-saved registers
   if (reg_map != NULL) {
     for(int i = 0; i < RegisterMap::reg_count; i++) {
-#ifdef AMD64
+#if defined(AMD64) || defined(AARCH64)
       // The register map has one entry for every int (32-bit value), so
       // 64-bit physical registers have two entries in the map, one for
       // each half.  Ignore the high halves of 64-bit registers, just like


### PR DESCRIPTION
### Description
Upgrade aarch64 port to Icedtea3.11.


### Related issues


### Motivation and context
Keep current with Icedtea aarch64 port.


### How has this been tested?
Hotspot jtreg tests pass better than x64 port.

### Platform information
    Works on OS: Amazon Linux 2 only
    Applies to version Corretto-8.202.08.3


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
