### PR TITLE
Provide 'java' to yum in the generic RPM.

### DIFF
--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -98,6 +98,8 @@ task generateJdkRpm(type: Rpm) {
     preUninstall file("$buildRoot/scripts/preun_javac.sh")
 
     provides(jdkPackageName, "${epoch}:${version}-${release}", EQUAL)
+    provides('java', "${epoch}:1.8.0", EQUAL)
+    provides('java-headless', "${epoch}:1.8.0", EQUAL)
     provides('java-devel', "${epoch}:1.8.0", EQUAL)
     provides('java-devel-openjdk', "${epoch}:${project.version.full}", EQUAL)
     provides('java-devel-openjdk-devel', "${epoch}:${version}-${release}.x86_64", EQUAL)

--- a/installers/linux/universal/test/docker/rpm-provide-java/Dockerfile
+++ b/installers/linux/universal/test/docker/rpm-provide-java/Dockerfile
@@ -1,0 +1,30 @@
+#Copyright (c) 2019, Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+#This code is free software; you can redistribute it and/or modify it
+#under the terms of the GNU General Public License version 2 only, as
+#published by the Free Software Foundation. Amazon designates this
+#particular file as subject to the "Classpath" exception as provided
+#by Oracle in the LICENSE file that accompanied this code.
+#
+#This code is distributed in the hope that it will be useful, but WITHOUT
+#ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+#version 2 for more details (a copy is included in the LICENSE file that
+#accompanied this code).
+#
+#You should have received a copy of the GNU General Public License version
+#2 along with this work; if not, write to the Free Software Foundation,
+#Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# This image is used for integration testing toward Corretto
+# Debian package.
+
+FROM amazonlinux:2
+
+COPY *.rpm .
+COPY run_test.sh .
+RUN yum localinstall -y *.rpm
+
+ENTRYPOINT ["/run_test.sh"]
+

--- a/installers/linux/universal/test/docker/rpm-provide-java/run_test.sh
+++ b/installers/linux/universal/test/docker/rpm-provide-java/run_test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+#Copyright (c) 2019, Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+#This code is free software; you can redistribute it and/or modify it
+#under the terms of the GNU General Public License version 2 only, as
+#published by the Free Software Foundation. Amazon designates this
+#particular file as subject to the "Classpath" exception as provided
+#by Oracle in the LICENSE file that accompanied this code.
+#
+#This code is distributed in the hope that it will be useful, but WITHOUT
+#ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+#version 2 for more details (a copy is included in the LICENSE file that
+#accompanied this code).
+#
+#You should have received a copy of the GNU General Public License version
+#2 along with this work; if not, write to the Free Software Foundation,
+#Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+set -Eeuo pipefail
+
+assertOpenJdkNotInstalled() {
+  if yum list installed java-1.8.0-openjdk >/dev/null 2>&1; then
+    echo "Fail: java-1.8.0-openjdk was installed"
+    exit 1
+  fi
+  if yum list installed java-1.8.0-openjdk-devel >/dev/null 2>&1; then
+    echo "Fail: java-1.8.0-openjdk-devel was installed"
+    exit 1
+  fi
+}
+
+assertOpenJdkNotInstalled
+yum install -y tomcat
+assertOpenJdkNotInstalled
+


### PR DESCRIPTION
This fixes #67 by adding `java` and `java-headless` as provided by the generic RPM. In addition, there's a test showing that installing jetty will not bring in java-1.8.0-openjdk on AL2.
