### PR TITLE
[aarch64] add JDK-8224671 and JDK-8219006

### DIFF
--- a/src/hotspot/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
@@ -2309,7 +2309,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
     if (copyfunc_addr != NULL) {
       // r0 is -1^K where K == partial copied count
-      __ eonw(rscratch1, r0, 0);
+      __ eonw(rscratch1, r0, zr);
       // adjust length down and src/end pos up by partial copied count
       __ subw(length, length, rscratch1);
       __ addw(src_pos, src_pos, rscratch1);

--- a/src/hotspot/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
@@ -1735,7 +1735,7 @@ class StubGenerator: public StubCodeGenerator {
 
 
   // Helper for generating a dynamic type check.
-  // Smashes rscratch1.
+  // Smashes rscratch1, rscratch2.
   void generate_type_check(Register sub_klass,
                            Register super_check_offset,
                            Register super_klass,
@@ -2165,6 +2165,9 @@ class StubGenerator: public StubCodeGenerator {
     const Register dst_pos    = c_rarg3;  // destination position
     const Register length     = c_rarg4;
 
+    // Registers used as temps
+    const Register dst_klass  = c_rarg5;
+
     StubCodeMark mark(this, "StubRoutines", name);
 
     __ align(CodeEntryAlignment);
@@ -2369,8 +2372,7 @@ class StubGenerator: public StubCodeGenerator {
       arraycopy_range_checks(src, src_pos, dst, dst_pos, scratch_length,
                              r18, L_failed);
 
-      const Register rscratch2_dst_klass = rscratch2;
-      __ load_klass(rscratch2_dst_klass, dst); // reload
+      __ load_klass(dst_klass, dst); // reload
 
       // Marshal the base address arguments now, freeing registers.
       __ lea(from, Address(src, src_pos, Address::lsl(LogBytesPerHeapOop)));
@@ -2380,24 +2382,25 @@ class StubGenerator: public StubCodeGenerator {
       __ movw(count, length);           // length (reloaded)
       Register sco_temp = c_rarg3;      // this register is free now
       assert_different_registers(from, to, count, sco_temp,
-                                 rscratch2_dst_klass, scratch_src_klass);
+                                 dst_klass, scratch_src_klass);
       // assert_clean_int(count, sco_temp);
 
       // Generate the type check.
       const int sco_offset = in_bytes(Klass::super_check_offset_offset());
-      __ ldrw(sco_temp, Address(rscratch2_dst_klass, sco_offset));
-      // assert_clean_int(sco_temp, r18);
-      generate_type_check(scratch_src_klass, sco_temp, rscratch2_dst_klass, L_plain_copy);
+      __ ldrw(sco_temp, Address(dst_klass, sco_offset));
+
+      // Smashes rscratch1, rscratch2
+      generate_type_check(scratch_src_klass, sco_temp, dst_klass, L_plain_copy);
 
       // Fetch destination element klass from the ObjArrayKlass header.
       int ek_offset = in_bytes(ObjArrayKlass::element_klass_offset());
-      __ ldr(rscratch2_dst_klass, Address(rscratch2_dst_klass, ek_offset));
-      __ ldrw(sco_temp, Address(rscratch2_dst_klass, sco_offset));
+      __ ldr(dst_klass, Address(dst_klass, ek_offset));
+      __ ldrw(sco_temp, Address(dst_klass, sco_offset));
 
       // the checkcast_copy loop needs two extra arguments:
       assert(c_rarg3 == sco_temp, "#3 already in place");
       // Set up arguments for checkcast_copy_entry.
-      __ mov(c_rarg4, rscratch2_dst_klass);  // dst.klass.element_klass
+      __ mov(c_rarg4, dst_klass);  // dst.klass.element_klass
       __ b(RuntimeAddress(checkcast_copy_entry));
     }
 


### PR DESCRIPTION
These 2 bugfixes fix intrinsic System.arraycopy on aarch64

Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description


### Related issues
JDK-1560

### Motivation and context
we run into problem for[ spring-framework ](https://github.com/spring-projects/spring-framework)
./gradlew :spring-context:test will throw 2 failed due to IndexOutOfBoundsException.

### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
