### PR TITLE
Fix bad rebase of aarch64 port on 8u212.

### DIFF
--- a/src/hotspot/src/os/linux/vm/os_linux.hpp
+++ b/src/hotspot/src/os/linux/vm/os_linux.hpp
@@ -248,8 +248,6 @@ class Linux {
   // LinuxThreads work-around for 6292965
   static int safe_cond_timedwait(pthread_cond_t *_cond, pthread_mutex_t *_mutex, const struct timespec *_abstime);
 
-  static void expand_stack_to(address bottom);
-
 private:
   static void expand_stack_to(address bottom);
 


### PR DESCRIPTION
### Description
Diff/Patch has created two declarations of the same function on `src/hotspot/src/os/linux/vm/os_linux.hpp`. This breaks the build.

### Motivation and context
Corretto includes the IcedTea port of aarch64. However, some of the changes that were done for the port are also upstreamed into the openjdk repository. During a rebase, Diff/Patch failed to detect a conflict. That code breaks the build.
