### PR TITLE
Use Corretto version as the value of the CFBundleVersion

### DIFF
--- a/installers/mac/pkg/templates/introduction.html.template
+++ b/installers/mac/pkg/templates/introduction.html.template
@@ -82,5 +82,5 @@ body .markdown-body {
 
 </style><title>introduction</title></head><body><article class="markdown-body"><h3>
 <a class="anchor" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Amazon Corretto @major@ Installer</h3>
-<p>You will be guided through the steps necessary to install Amazon Corretto @major@.</p>
+<p>You will be guided through the steps necessary to install Amazon Corretto @full@.</p>
 </article></body></html>

--- a/installers/mac/tar/templates/Info.plist.template
+++ b/installers/mac/tar/templates/Info.plist.template
@@ -21,7 +21,7 @@
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>CFBundleVersion</key>
-        <string>1.8.0_@update@</string>
+        <string>@full@</string>
         <key>JavaVM</key>
         <dict>
                 <key>JVMCapabilities</key>


### PR DESCRIPTION
The mac installer reads the CFBundleVersion key from `Info.plist` to determine if a component should be installed. Change the key to reflect the corretto version so the installer will not overwrite a new corretto version with an old one.

This also fixes #112 on Mac.

### Test
```
$ sudo installer -pkg amazon-corretto-8.202.08.2-macosx-x64.pkg -target / && java -version
openjdk version "1.8.0_202"
OpenJDK Runtime Environment Corretto-8.202.08.2 (build 1.8.0_202-b08)
OpenJDK 64-Bit Server VM Corretto-8.202.08.2 (build 25.202-b08, mixed mode)

$ sudo installer -pkg amazon-corretto-8.212.04.2-macosx-x64.pkg -target / && java -version
openjdk version "1.8.0_212"
OpenJDK Runtime Environment Corretto-8.212.04.2 (build 1.8.0_212-b04)
OpenJDK 64-Bit Server VM Corretto-8.212.04.2 (build 25.212-b04, mixed mode)

$ sudo installer -pkg amazon-corretto-8.202.08.2-macosx-x64.pkg -target / && java -version
openjdk version "1.8.0_212"
OpenJDK Runtime Environment Corretto-8.212.04.2 (build 1.8.0_212-b04)
OpenJDK 64-Bit Server VM Corretto-8.212.04.2 (build 25.212-b04, mixed mode)
```