### PR TITLE
Backport JDK-8155627: Enable SA on AArch64

### DIFF
--- a/src/common/autoconf/generated-configure.sh
+++ b/src/common/autoconf/generated-configure.sh
@@ -14638,9 +14638,6 @@ $as_echo "$with_jvm_variants" >&6; }
   if test "x$VAR_CPU" = xppc64 -o "x$VAR_CPU" = xppc64le ; then
     INCLUDE_SA=false
   fi
-  if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
-    INCLUDE_SA=false
-  fi
 
 
   if test "x$OPENJDK_TARGET_OS" = "xmacosx"; then

--- a/src/common/autoconf/jdk-options.m4
+++ b/src/common/autoconf/jdk-options.m4
@@ -161,9 +161,6 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JVM_VARIANTS],
   if test "x$VAR_CPU" = xppc64 -o "x$VAR_CPU" = xppc64le ; then
     INCLUDE_SA=false
   fi
-  if test "x$OPENJDK_TARGET_CPU" = xaarch64; then
-    INCLUDE_SA=false
-  fi
   AC_SUBST(INCLUDE_SA)
 
   if test "x$OPENJDK_TARGET_OS" = "xmacosx"; then

--- a/src/hotspot/agent/src/share/classes/sun/jvm/hotspot/runtime/aarch64/AARCH64Frame.java
+++ b/src/hotspot/agent/src/share/classes/sun/jvm/hotspot/runtime/aarch64/AARCH64Frame.java
@@ -49,11 +49,12 @@ public class AARCH64Frame extends Frame {
   private static final int SENDER_SP_OFFSET           =  2;
 
   // Interpreter frames
-  private static final int INTERPRETER_FRAME_MIRROR_OFFSET    =  2; // for native calls only
   private static final int INTERPRETER_FRAME_SENDER_SP_OFFSET = -1;
   private static final int INTERPRETER_FRAME_LAST_SP_OFFSET   = INTERPRETER_FRAME_SENDER_SP_OFFSET - 1;
   private static final int INTERPRETER_FRAME_METHOD_OFFSET    = INTERPRETER_FRAME_LAST_SP_OFFSET - 1;
   private static       int INTERPRETER_FRAME_MDX_OFFSET;         // Non-core builds only
+  private static       int INTERPRETER_FRAME_PADDING_OFFSET;
+  private static       int INTERPRETER_FRAME_MIRROR_OFFSET;
   private static       int INTERPRETER_FRAME_CACHE_OFFSET;
   private static       int INTERPRETER_FRAME_LOCALS_OFFSET;
   private static       int INTERPRETER_FRAME_BCX_OFFSET;
@@ -79,7 +80,9 @@ public class AARCH64Frame extends Frame {
 
   private static synchronized void initialize(TypeDataBase db) {
     INTERPRETER_FRAME_MDX_OFFSET                  = INTERPRETER_FRAME_METHOD_OFFSET - 1;
-    INTERPRETER_FRAME_CACHE_OFFSET                = INTERPRETER_FRAME_MDX_OFFSET - 1;
+    INTERPRETER_FRAME_PADDING_OFFSET              = INTERPRETER_FRAME_MDX_OFFSET - 1;
+    INTERPRETER_FRAME_MIRROR_OFFSET               = INTERPRETER_FRAME_PADDING_OFFSET - 1;
+    INTERPRETER_FRAME_CACHE_OFFSET                = INTERPRETER_FRAME_MIRROR_OFFSET - 1;
     INTERPRETER_FRAME_LOCALS_OFFSET               = INTERPRETER_FRAME_CACHE_OFFSET - 1;
     INTERPRETER_FRAME_BCX_OFFSET                  = INTERPRETER_FRAME_LOCALS_OFFSET - 1;
     INTERPRETER_FRAME_INITIAL_SP_OFFSET           = INTERPRETER_FRAME_BCX_OFFSET - 1;


### PR DESCRIPTION
The original configuration set flag INCLUDE_SA as false when the CPU
arch is aarch64, causing `sa-jdi.jar` missing in the Corretto-8 build.
Without the jar, debug tools such `hsdb` and `clhsdb` are not able to
function correctly.

This is backported from JDK-8155627: https://bugs.openjdk.java.net/browse/JDK-8155627

### Test
```
# ./gradlew :installers:linux:universal:tar:build
# tar tf ./installers/linux/universal/tar/corretto-build/distributions/amazon-corretto-8.212.04.2-linux-aarch64.tar.gz  | grep "sa-jdi.jar"
amazon-corretto-8.212.04.2-linux-aarch64/lib/sa-jdi.jar
```