### PR TITLE
update new atomic operations for ARM64

### DIFF
--- a/src/hotspot/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
@@ -1603,56 +1603,14 @@ void LIR_Assembler::emit_opTypeCheck(LIR_OpTypeCheck* op) {
 }
 
 void LIR_Assembler::casw(Register addr, Register newval, Register cmpval) {
-  if (UseLSE) {
-    __ mov(rscratch1, cmpval);
-    __ casal(Assembler::word, rscratch1, newval, addr);
-    __ cmpw(rscratch1, cmpval);
-    __ cset(rscratch1, Assembler::NE);
-  } else {
-    Label retry_load, nope;
-    // flush and load exclusive from the memory location
-    // and fail if it is not what we expect
-    if ((VM_Version::cpu_cpuFeatures() & VM_Version::CPU_STXR_PREFETCH))
-      __ prfm(Address(addr), PSTL1STRM);
-    __ bind(retry_load);
-    __ ldaxrw(rscratch1, addr);
-    __ cmpw(rscratch1, cmpval);
-    __ cset(rscratch1, Assembler::NE);
-    __ br(Assembler::NE, nope);
-    // if we store+flush with no intervening write rscratch1 wil be zero
-    __ stlxrw(rscratch1, newval, addr);
-    // retry so we only ever return after a load fails to compare
-    // ensures we don't return a stale value after a failed write.
-    __ cbnzw(rscratch1, retry_load);
-    __ bind(nope);
-  }
+  __ cmpxchg(addr, cmpval, newval, Assembler::word, /* acquire*/ true, /* release*/ true, rscratch1);
+  __ cset(rscratch1, Assembler::NE);
   __ membar(__ AnyAny);
 }
 
 void LIR_Assembler::casl(Register addr, Register newval, Register cmpval) {
-  if (UseLSE) {
-    __ mov(rscratch1, cmpval);
-    __ casal(Assembler::xword, rscratch1, newval, addr);
-    __ cmp(rscratch1, cmpval);
-    __ cset(rscratch1, Assembler::NE);
-  } else {
-    Label retry_load, nope;
-    // flush and load exclusive from the memory location
-    // and fail if it is not what we expect
-    if ((VM_Version::cpu_cpuFeatures() & VM_Version::CPU_STXR_PREFETCH))
-      __ prfm(Address(addr), PSTL1STRM);
-    __ bind(retry_load);
-    __ ldaxr(rscratch1, addr);
-    __ cmp(rscratch1, cmpval);
-    __ cset(rscratch1, Assembler::NE);
-    __ br(Assembler::NE, nope);
-    // if we store+flush with no intervening write rscratch1 wil be zero
-    __ stlxr(rscratch1, newval, addr);
-    // retry so we only ever return after a load fails to compare
-    // ensures we don't return a stale value after a failed write.
-    __ cbnz(rscratch1, retry_load);
-    __ bind(nope);
-  }
+  __ cmpxchg(addr, cmpval, newval, Assembler::xword, /* acquire*/ true, /* release*/ true, rscratch1);
+  __ cset(rscratch1, Assembler::NE);
   __ membar(__ AnyAny);
 }
 
@@ -3192,39 +3150,33 @@ void LIR_Assembler::atomic_op(LIR_Code code, LIR_Opr src, LIR_Opr data, LIR_Opr 
   Address addr = as_Address(src->as_address_ptr(), noreg);
   BasicType type = src->type();
   bool is_oop = type == T_OBJECT || type == T_ARRAY;
-  Assembler::operand_size sz = Assembler::xword;
 
-  void (MacroAssembler::* lda)(Register Rd, Register Ra);
-  void (MacroAssembler::* add)(Register Rd, Register Rn, RegisterOrConstant increment);
-  void (MacroAssembler::* stl)(Register Rs, Register Rt, Register Rn);
+  void (MacroAssembler::* add)(Register prev, RegisterOrConstant incr, Register addr);
+  void (MacroAssembler::* xchg)(Register prev, Register newv, Register addr);
 
   switch(type) {
   case T_INT:
-    lda = &MacroAssembler::ldaxrw;
-    add = &MacroAssembler::addw;
-    stl = &MacroAssembler::stlxrw;
-    sz = Assembler::word;
+    xchg = &MacroAssembler::atomic_xchgalw;
+    add = &MacroAssembler::atomic_addalw;
     break;
   case T_LONG:
-    lda = &MacroAssembler::ldaxr;
-    add = &MacroAssembler::add;
-    stl = &MacroAssembler::stlxr;
+    xchg = &MacroAssembler::atomic_xchgal;
+    add = &MacroAssembler::atomic_addal;
     break;
   case T_OBJECT:
   case T_ARRAY:
     if (UseCompressedOops) {
-      lda = &MacroAssembler::ldaxrw;
-      add = &MacroAssembler::addw;
-      stl = &MacroAssembler::stlxrw;
-      sz = Assembler::word;
+      xchg = &MacroAssembler::atomic_xchgalw;
+      add = &MacroAssembler::atomic_addalw;
     } else {
-      lda = &MacroAssembler::ldaxr;
-      add = &MacroAssembler::add;
-      stl = &MacroAssembler::stlxr;
+      xchg = &MacroAssembler::atomic_xchgal;
+      add = &MacroAssembler::atomic_addal;
     }
     break;
   default:
     ShouldNotReachHere();
+    xchg = &MacroAssembler::atomic_xchgal;
+    add = &MacroAssembler::atomic_addal; // unreachable
   }
 
   switch (code) {
@@ -3234,32 +3186,16 @@ void LIR_Assembler::atomic_op(LIR_Code code, LIR_Opr src, LIR_Opr data, LIR_Opr 
       Register tmp = as_reg(tmp_op);
       Register dst = as_reg(dest);
       if (data->is_constant()) {
-	inc = RegisterOrConstant(as_long(data));
-	assert_different_registers(dst, addr.base(), tmp,
-				   rscratch1, rscratch2);
+        inc = RegisterOrConstant(as_long(data));
+        assert_different_registers(dst, addr.base(), tmp,
+                rscratch1, rscratch2);
       } else {
-	inc = RegisterOrConstant(as_reg(data));
-	assert_different_registers(inc.as_register(), dst, addr.base(), tmp,
-				   rscratch1, rscratch2);
+        inc = RegisterOrConstant(as_reg(data));
+        assert_different_registers(inc.as_register(), dst, addr.base(), tmp,
+                rscratch1, rscratch2);
       }
       __ lea(tmp, addr);
-      if (UseLSE) {
-        if (inc.is_register()) {
-          __ ldaddal(sz, inc.as_register(), dst, tmp);
-        } else {
-          __ mov(rscratch2, inc.as_constant());
-          __ ldaddal(sz, rscratch2, dst, tmp);
-        }
-      } else {
-        Label again;
-        if ((VM_Version::cpu_cpuFeatures() & VM_Version::CPU_STXR_PREFETCH))
-          __ prfm(Address(tmp), PSTL1STRM);
-        __ bind(again);
-        (_masm->*lda)(dst, tmp);
-        (_masm->*add)(rscratch1, dst, inc);
-        (_masm->*stl)(rscratch2, rscratch1, tmp);
-        __ cbnzw(rscratch2, again);
-      }
+      (_masm->*add)(dst, inc, tmp);
       break;
     }
   case lir_xchg:
@@ -3273,19 +3209,9 @@ void LIR_Assembler::atomic_op(LIR_Code code, LIR_Opr src, LIR_Opr data, LIR_Opr 
       }
       assert_different_registers(obj, addr.base(), tmp, rscratch2, dst);
       __ lea(tmp, addr);
-      if (UseLSE) {
-        __ swp(sz, obj, dst, tmp);
-      } else {
-        Label again;
-        if ((VM_Version::cpu_cpuFeatures() & VM_Version::CPU_STXR_PREFETCH))
-          __ prfm(Address(tmp), PSTL1STRM);
-        __ bind(again);
-        (_masm->*lda)(dst, tmp);
-        (_masm->*stl)(rscratch2, obj, tmp);
-        __ cbnzw(rscratch2, again);
-      }
+      (_masm->*xchg)(dst, obj, tmp);
       if (is_oop && UseCompressedOops) {
-	__ decode_heap_oop(dst);
+        __ decode_heap_oop(dst);
       }
     }
     break;

--- a/src/hotspot/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/c1_LIRAssembler_aarch64.cpp
@@ -3204,10 +3204,10 @@ void LIR_Assembler::atomic_op(LIR_Code code, LIR_Opr src, LIR_Opr data, LIR_Opr 
       Register obj = as_reg(data);
       Register dst = as_reg(dest);
       if (is_oop && UseCompressedOops) {
-        __ encode_heap_oop(rscratch1, obj);
-        obj = rscratch1;
+        __ encode_heap_oop(rscratch2, obj);
+        obj = rscratch2;
       }
-      assert_different_registers(obj, addr.base(), tmp, rscratch2, dst);
+      assert_different_registers(obj, addr.base(), tmp, rscratch1, dst);
       __ lea(tmp, addr);
       (_masm->*xchg)(dst, obj, tmp);
       if (is_oop && UseCompressedOops) {

--- a/src/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp
@@ -2221,8 +2221,8 @@ static bool different(Register a, RegisterOrConstant b, Register c) {
     return a != b.as_register() && a != c && b.as_register() != c;
 }
 
-#define ATOMIC_OP(LDXR, OP, IOP, AOP, STXR, sz)                         \
-void MacroAssembler::atomic_##OP(Register prev, RegisterOrConstant incr, Register addr) { \
+#define ATOMIC_OP(NAME, LDXR, OP, IOP, AOP, STXR, sz)                   \
+void MacroAssembler::atomic_##NAME(Register prev, RegisterOrConstant incr, Register addr) { \
   if (UseLSE) {                                                         \
     prev = prev->is_valid() ? prev : zr;                                \
     if (incr.is_register()) {                                           \
@@ -2250,16 +2250,18 @@ void MacroAssembler::atomic_##OP(Register prev, RegisterOrConstant incr, Registe
   }                                                                     \
 }
 
-ATOMIC_OP(ldxr, add, sub, ldadd, stxr, Assembler::xword)
-ATOMIC_OP(ldxrw, addw, subw, ldadd, stxrw, Assembler::word)
+ATOMIC_OP(add, ldxr, add, sub, ldadd, stxr, Assembler::xword)
+ATOMIC_OP(addw, ldxrw, addw, subw, ldadd, stxrw, Assembler::word)
+ATOMIC_OP(addal, ldaxr, add, sub, ldaddal, stlxr, Assembler::xword)
+ATOMIC_OP(addalw, ldaxrw, addw, subw, ldaddal, stlxrw, Assembler::word)
 
 #undef ATOMIC_OP
 
-#define ATOMIC_XCHG(OP, LDXR, STXR, sz)                                 \
+#define ATOMIC_XCHG(OP, AOP, LDXR, STXR, sz)                            \
 void MacroAssembler::atomic_##OP(Register prev, Register newv, Register addr) {	\
   if (UseLSE) {                                                         \
     prev = prev->is_valid() ? prev : zr;                                \
-    swp(sz, newv, prev, addr);                                          \
+    AOP(sz, newv, prev, addr);                                          \
     return;                                                             \
   }                                                                     \
   Register result = rscratch2;						\
@@ -2277,8 +2279,10 @@ void MacroAssembler::atomic_##OP(Register prev, Register newv, Register addr) {	
     mov(prev, result);							\
 }
 
-ATOMIC_XCHG(xchg, ldxr, stxr, Assembler::xword)
-ATOMIC_XCHG(xchgw, ldxrw, stxrw, Assembler::word)
+ATOMIC_XCHG(xchg, swp, ldxr, stxr, Assembler::xword)
+ATOMIC_XCHG(xchgw, swp, ldxrw, stxrw, Assembler::word)
+ATOMIC_XCHG(xchgal, swpal, ldaxr, stlxr, Assembler::xword)
+ATOMIC_XCHG(xchgalw, swpal, ldaxrw, stlxrw, Assembler::word)
 
 #undef ATOMIC_XCHG
 

--- a/src/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.hpp
+++ b/src/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.hpp
@@ -981,9 +981,13 @@ public:
 
   void atomic_add(Register prev, RegisterOrConstant incr, Register addr);
   void atomic_addw(Register prev, RegisterOrConstant incr, Register addr);
+  void atomic_addal(Register prev, RegisterOrConstant incr, Register addr);
+  void atomic_addalw(Register prev, RegisterOrConstant incr, Register addr);
 
   void atomic_xchg(Register prev, Register newv, Register addr);
   void atomic_xchgw(Register prev, Register newv, Register addr);
+  void atomic_xchgal(Register prev, Register newv, Register addr);
+  void atomic_xchgalw(Register prev, Register newv, Register addr);
 
   void orptr(Address adr, RegisterOrConstant src) {
     ldr(rscratch2, adr);

--- a/src/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.hpp
+++ b/src/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.hpp
@@ -787,10 +787,10 @@ public:
   void store_check_part_1(Register obj);
   void store_check_part_2(Register obj);
 
-  // oop manipulations
   // C 'boolean' to Java boolean: x == 0 ? 0 : 1
   void c2bool(Register x);
 
+  // oop manipulations
   void load_klass(Register dst, Register src);
   void store_klass(Register dst, Register src);
   void cmp_klass(Register oop, Register trial_klass, Register tmp);

--- a/src/hotspot/src/cpu/aarch64/vm/templateInterpreter_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/templateInterpreter_aarch64.cpp
@@ -2054,22 +2054,10 @@ void TemplateInterpreterGenerator::count_bytecode() {
   Register rscratch3 = r0;
   __ push(rscratch1);
   __ push(rscratch2);
-  __ mov(rscratch2, (address) &BytecodeCounter::_counter_value);
-  if (UseLSE) {
-    __ mov(rscratch1, 1);
-    __ ldadd(Assembler::xword, rscratch1, zr, rscratch2);
-  } else {
-    __ push(rscratch3);
-    Label L;
-    if ((VM_Version::cpu_cpuFeatures() & VM_Version::CPU_STXR_PREFETCH))
-      __ prfm(Address(rscratch2), PSTL1STRM);
-    __ bind(L);
-    __ ldxr(rscratch1, rscratch2);
-    __ add(rscratch1, rscratch1, 1);
-    __ stxr(rscratch3, rscratch1, rscratch2);
-    __ cbnzw(rscratch3, L);
-    __ pop(rscratch3);
-  }
+  __ push(rscratch3);
+  __ mov(rscratch3, (address) &BytecodeCounter::_counter_value);
+  __ atomic_add(noreg, 1, rscratch3);
+  __ pop(rscratch3);
   __ pop(rscratch2);
   __ pop(rscratch1);
 }

--- a/src/hotspot/src/cpu/aarch64/vm/templateTable_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/templateTable_aarch64.cpp
@@ -2796,7 +2796,7 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static) {
   {
     Label notVolatile;
     __ tbz(r5, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
-    __ membar(MacroAssembler::StoreLoad);
+    __ membar(MacroAssembler::StoreLoad | MacroAssembler::StoreStore);
     __ bind(notVolatile);
   }
 }
@@ -2934,7 +2934,7 @@ void TemplateTable::fast_storefield(TosState state)
   {
     Label notVolatile;
     __ tbz(r3, ConstantPoolCacheEntry::is_volatile_shift, notVolatile);
-    __ membar(MacroAssembler::StoreLoad);
+    __ membar(MacroAssembler::StoreLoad | MacroAssembler::StoreStore);
     __ bind(notVolatile);
   }
 }

--- a/src/hotspot/src/share/vm/gc_implementation/g1/g1CodeCacheRemSet.cpp
+++ b/src/hotspot/src/share/vm/gc_implementation/g1/g1CodeCacheRemSet.cpp
@@ -205,7 +205,9 @@ CodeRootSetTable* G1CodeRootSet::load_acquire_table() {
 }
 
 void G1CodeRootSet::allocate_small_table() {
-  _table = new CodeRootSetTable(SmallSize);
+  CodeRootSetTable* temp = new CodeRootSetTable(SmallSize);
+
+  OrderAccess::release_store_ptr(&_table, temp);
 }
 
 void CodeRootSetTable::purge_list_append(CodeRootSetTable* table) {


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
update new atomic operations for ARM64

### Related issues


### Motivation and context
sync up with upstream ARM64 repo.

### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
