### PR TITLE
[backport] 8062808:Turn on the -Wreturn-type warning

### DIFF
--- a/src/hotspot/src/cpu/x86/vm/x86_32.ad
+++ b/src/hotspot/src/cpu/x86/vm/x86_32.ad
@@ -1250,6 +1250,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
 
 
   Unimplemented();
+  return 0; // Mute compiler
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
+++ b/src/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
@@ -540,7 +540,7 @@ JVM_handle_linux_signal(int sig,
   err.report_and_die();
 
   ShouldNotReachHere();
-  return false; // Mute compiler
+  return true; // Mute compiler
 }
 
 void os::Linux::init_thread_fpu_state(void) {

--- a/src/hotspot/src/share/vm/classfile/defaultMethods.cpp
+++ b/src/hotspot/src/share/vm/classfile/defaultMethods.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -506,7 +506,7 @@ Symbol* MethodFamily::generate_method_message(Symbol *klass_name, Method* method
   ss.write((const char*)name->bytes(), name->utf8_length());
   ss.write((const char*)signature->bytes(), signature->utf8_length());
   ss.print(" is abstract");
-  return SymbolTable::new_symbol(ss.base(), (int)ss.size(), CHECK_NULL);
+  return SymbolTable::new_symbol(ss.base(), (int)ss.size(), THREAD);
 }
 
 Symbol* MethodFamily::generate_conflicts_message(GrowableArray<Method*>* methods, TRAPS) const {
@@ -521,7 +521,7 @@ Symbol* MethodFamily::generate_conflicts_message(GrowableArray<Method*>* methods
     ss.print(".");
     ss.write((const char*)name->bytes(), name->utf8_length());
   }
-  return SymbolTable::new_symbol(ss.base(), (int)ss.size(), CHECK_NULL);
+  return SymbolTable::new_symbol(ss.base(), (int)ss.size(), THREAD);
 }
 
 

--- a/src/hotspot/src/share/vm/classfile/symbolTable.cpp
+++ b/src/hotspot/src/share/vm/classfile/symbolTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -249,7 +249,7 @@ Symbol* SymbolTable::lookup(const char* name, int len, TRAPS) {
   MutexLocker ml(SymbolTable_lock, THREAD);
 
   // Otherwise, add to symbol to table
-  return the_table()->basic_add(index, (u1*)name, len, hashValue, true, CHECK_NULL);
+  return the_table()->basic_add(index, (u1*)name, len, hashValue, true, THREAD);
 }
 
 Symbol* SymbolTable::lookup(const Symbol* sym, int begin, int end, TRAPS) {
@@ -288,7 +288,7 @@ Symbol* SymbolTable::lookup(const Symbol* sym, int begin, int end, TRAPS) {
   // Grab SymbolTable_lock first.
   MutexLocker ml(SymbolTable_lock, THREAD);
 
-  return the_table()->basic_add(index, (u1*)buffer, len, hashValue, true, CHECK_NULL);
+  return the_table()->basic_add(index, (u1*)buffer, len, hashValue, true, THREAD);
 }
 
 Symbol* SymbolTable::lookup_only(const char* name, int len,

--- a/src/hotspot/src/share/vm/classfile/systemDictionary.cpp
+++ b/src/hotspot/src/share/vm/classfile/systemDictionary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,15 +229,15 @@ Klass* SystemDictionary::resolve_or_null(Symbol* class_name, Handle class_loader
                  class_name->as_C_string(),
                  class_loader.is_null() ? "null" : class_loader->klass()->name()->as_C_string()));
   if (FieldType::is_array(class_name)) {
-    return resolve_array_class_or_null(class_name, class_loader, protection_domain, CHECK_NULL);
+    return resolve_array_class_or_null(class_name, class_loader, protection_domain, THREAD);
   } else if (FieldType::is_obj(class_name)) {
     ResourceMark rm(THREAD);
     // Ignore wrapping L and ;.
     TempNewSymbol name = SymbolTable::new_symbol(class_name->as_C_string() + 1,
                                    class_name->utf8_length() - 2, CHECK_NULL);
-    return resolve_instance_class_or_null(name, class_loader, protection_domain, CHECK_NULL);
+    return resolve_instance_class_or_null(name, class_loader, protection_domain, THREAD);
   } else {
-    return resolve_instance_class_or_null(class_name, class_loader, protection_domain, CHECK_NULL);
+    return resolve_instance_class_or_null(class_name, class_loader, protection_domain, THREAD);
   }
 }
 

--- a/src/hotspot/src/share/vm/memory/heapInspection.hpp
+++ b/src/hotspot/src/share/vm/memory/heapInspection.hpp
@@ -367,7 +367,7 @@ class HeapInspection : public StackObj {
       _csv_format(csv_format), _print_help(print_help),
       _print_class_stats(print_class_stats), _columns(columns) {}
   void heap_inspection(outputStream* st) NOT_SERVICES_RETURN;
-  size_t populate_table(KlassInfoTable* cit, BoolObjectClosure* filter = NULL) NOT_SERVICES_RETURN_(0);
+  size_t populate_table(KlassInfoTable* cit, BoolObjectClosure* filter = NULL) NOT_SERVICES_RETURN;
   static void find_instances_at_safepoint(Klass* k, GrowableArray<oop>* result) NOT_SERVICES_RETURN;
  private:
   void iterate_over_heap(KlassInfoTable* cit, BoolObjectClosure* filter = NULL);

--- a/src/hotspot/src/share/vm/memory/metaspaceShared.hpp
+++ b/src/hotspot/src/share/vm/memory/metaspaceShared.hpp
@@ -93,7 +93,7 @@ class MetaspaceShared : AllStatic {
   static void preload_and_dump(TRAPS) NOT_CDS_RETURN;
   static int preload_and_dump(const char * class_list_path,
                               GrowableArray<Klass*>* class_promote_order,
-                              TRAPS) NOT_CDS_RETURN_(0);
+                              TRAPS) NOT_CDS_RETURN;
 
   static ReservedSpace* shared_rs() {
     CDS_ONLY(return _shared_rs);

--- a/src/hotspot/src/share/vm/oops/constantPool.hpp
+++ b/src/hotspot/src/share/vm/oops/constantPool.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -353,7 +353,7 @@ class ConstantPool : public Metadata {
 
   Klass* klass_at(int which, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    return klass_at_impl(h_this, which, CHECK_NULL);
+    return klass_at_impl(h_this, which, THREAD);
   }
 
   Symbol* klass_name_at(int which);  // Returns the name, w/o resolving.

--- a/src/hotspot/src/share/vm/prims/jvm.cpp
+++ b/src/hotspot/src/share/vm/prims/jvm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -908,7 +908,7 @@ JVM_END
 JVM_ENTRY(jboolean, JVM_KnownToNotExist(JNIEnv *env, jobject loader, const char *classname))
   JVMWrapper("JVM_KnownToNotExist");
 #if INCLUDE_CDS
-  return ClassLoaderExt::known_to_not_exist(env, loader, classname, CHECK_(false));
+  return ClassLoaderExt::known_to_not_exist(env, loader, classname, THREAD);
 #else
   return false;
 #endif
@@ -918,7 +918,7 @@ JVM_END
 JVM_ENTRY(jobjectArray, JVM_GetResourceLookupCacheURLs(JNIEnv *env, jobject loader))
   JVMWrapper("JVM_GetResourceLookupCacheURLs");
 #if INCLUDE_CDS
-  return ClassLoaderExt::get_lookup_cache_urls(env, loader, CHECK_NULL);
+  return ClassLoaderExt::get_lookup_cache_urls(env, loader, THREAD);
 #else
   return NULL;
 #endif
@@ -928,7 +928,7 @@ JVM_END
 JVM_ENTRY(jintArray, JVM_GetResourceLookupCache(JNIEnv *env, jobject loader, const char *resource_name))
   JVMWrapper("JVM_GetResourceLookupCache");
 #if INCLUDE_CDS
-  return ClassLoaderExt::get_lookup_cache(env, loader, resource_name, CHECK_NULL);
+  return ClassLoaderExt::get_lookup_cache(env, loader, resource_name, THREAD);
 #else
   return NULL;
 #endif
@@ -4343,7 +4343,7 @@ JVM_ENTRY(jlong,JVM_DTraceActivate(
     JVM_DTraceProvider* providers))
   JVMWrapper("JVM_DTraceActivate");
   return DTraceJSDT::activate(
-    version, module_name, providers_count, providers, CHECK_0);
+    version, module_name, providers_count, providers, THREAD);
 JVM_END
 
 JVM_ENTRY(jboolean,JVM_DTraceIsProbeEnabled(JNIEnv* env, jmethodID method))

--- a/src/hotspot/src/share/vm/runtime/perfData.hpp
+++ b/src/hotspot/src/share/vm/runtime/perfData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -773,7 +773,7 @@ class PerfDataManager : AllStatic {
     static PerfStringVariable* create_string_variable(CounterNS ns,
                                                       const char* name,
                                                       const char *s, TRAPS) {
-      return create_string_variable(ns, name, 0, s, CHECK_NULL);
+      return create_string_variable(ns, name, 0, s, THREAD);
     };
 
     static PerfLongVariable* create_long_variable(CounterNS ns,
@@ -784,7 +784,7 @@ class PerfDataManager : AllStatic {
     static PerfLongVariable* create_long_variable(CounterNS ns,
                                                   const char* name,
                                                   PerfData::Units u, TRAPS) {
-      return create_long_variable(ns, name, u, (jlong)0, CHECK_NULL);
+      return create_long_variable(ns, name, u, (jlong)0, THREAD);
     };
 
     static PerfLongVariable* create_long_variable(CounterNS, const char* name,
@@ -805,7 +805,7 @@ class PerfDataManager : AllStatic {
 
     static PerfLongCounter* create_long_counter(CounterNS ns, const char* name,
                                                 PerfData::Units u, TRAPS) {
-      return create_long_counter(ns, name, u, (jlong)0, CHECK_NULL);
+      return create_long_counter(ns, name, u, (jlong)0, THREAD);
     };
 
     static PerfLongCounter* create_long_counter(CounterNS ns, const char* name,
@@ -823,49 +823,49 @@ class PerfDataManager : AllStatic {
 
     static PerfConstant* create_constant(CounterNS ns, const char* name,
                                          PerfData::Units u, jlong val, TRAPS) {
-      return create_long_constant(ns, name, u, val, CHECK_NULL);
+      return create_long_constant(ns, name, u, val, THREAD);
     }
 
     static PerfVariable* create_variable(CounterNS ns, const char* name,
                                          PerfData::Units u, jlong ival, TRAPS) {
-      return create_long_variable(ns, name, u, ival, CHECK_NULL);
+      return create_long_variable(ns, name, u, ival, THREAD);
     }
 
     static PerfVariable* create_variable(CounterNS ns, const char* name,
                                          PerfData::Units u, TRAPS) {
-      return create_long_variable(ns, name, u, (jlong)0, CHECK_NULL);
+      return create_long_variable(ns, name, u, (jlong)0, THREAD);
     }
 
     static PerfVariable* create_variable(CounterNS ns, const char* name,
                                          PerfData::Units u, jlong* sp, TRAPS) {
-      return create_long_variable(ns, name, u, sp, CHECK_NULL);
+      return create_long_variable(ns, name, u, sp, THREAD);
     }
 
     static PerfVariable* create_variable(CounterNS ns, const char* name,
                                          PerfData::Units u,
                                          PerfSampleHelper* sh, TRAPS) {
-      return create_long_variable(ns, name, u, sh, CHECK_NULL);
+      return create_long_variable(ns, name, u, sh, THREAD);
     }
 
     static PerfCounter* create_counter(CounterNS ns, const char* name,
                                        PerfData::Units u, jlong ival, TRAPS) {
-      return create_long_counter(ns, name, u, ival, CHECK_NULL);
+      return create_long_counter(ns, name, u, ival, THREAD);
     }
 
     static PerfCounter* create_counter(CounterNS ns, const char* name,
                                        PerfData::Units u, TRAPS) {
-      return create_long_counter(ns, name, u, (jlong)0, CHECK_NULL);
+      return create_long_counter(ns, name, u, (jlong)0, THREAD);
     }
 
     static PerfCounter* create_counter(CounterNS ns, const char* name,
                                        PerfData::Units u, jlong* sp, TRAPS) {
-      return create_long_counter(ns, name, u, sp, CHECK_NULL);
+      return create_long_counter(ns, name, u, sp, THREAD);
     }
 
     static PerfCounter* create_counter(CounterNS ns, const char* name,
                                        PerfData::Units u,
                                        PerfSampleHelper* sh, TRAPS) {
-      return create_long_counter(ns, name, u, sh, CHECK_NULL);
+      return create_long_counter(ns, name, u, sh, THREAD);
     }
 
     static void destroy();

--- a/src/hotspot/src/share/vm/runtime/reflection.cpp
+++ b/src/hotspot/src/share/vm/runtime/reflection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1093,7 +1093,7 @@ oop Reflection::invoke(instanceKlassHandle klass, methodHandle reflected_method,
   } else {
     if (rtype == T_BOOLEAN || rtype == T_BYTE || rtype == T_CHAR || rtype == T_SHORT)
       narrow((jvalue*) result.get_value_addr(), rtype, CHECK_NULL);
-    return box((jvalue*) result.get_value_addr(), rtype, CHECK_NULL);
+    return box((jvalue*) result.get_value_addr(), rtype, THREAD);
   }
 }
 

--- a/src/hotspot/src/share/vm/runtime/sharedRuntime.cpp
+++ b/src/hotspot/src/share/vm/runtime/sharedRuntime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1045,7 +1045,7 @@ Handle SharedRuntime::find_callee_info(JavaThread* thread, Bytecodes::Code& bc, 
   // last java frame on stack (which includes native call frames)
   vframeStream vfst(thread, true);  // Do not skip and javaCalls
 
-  return find_callee_info_helper(thread, vfst, bc, callinfo, CHECK_(Handle()));
+  return find_callee_info_helper(thread, vfst, bc, callinfo, THREAD);
 }
 
 

--- a/src/hotspot/src/share/vm/services/memTracker.hpp
+++ b/src/hotspot/src/share/vm/services/memTracker.hpp
@@ -64,7 +64,7 @@ class MemTracker : AllStatic {
     const NativeCallStack& stack, MEMFLAGS flag = mtNone) { }
   static inline void record_virtual_memory_commit(void* addr, size_t size, const NativeCallStack& stack) { }
   static inline Tracker get_virtual_memory_uncommit_tracker() { return Tracker(); }
-  static inline Tracker get_virtual_memory_release_tracker() { }
+  static inline Tracker get_virtual_memory_release_tracker() { return Tracker(); }
   static inline void record_virtual_memory_type(void* addr, MEMFLAGS flag) { }
   static inline void record_thread_stack(void* addr, size_t size) { }
   static inline void release_thread_stack(void* addr, size_t size) { }


### PR DESCRIPTION
Corretto-8 has enabled -Wreturn-warning. This patch allows
slowdebug build.

Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
fix a bunch of places where return a dummy values
That makes compiler happy. 

### Related issues


### Motivation and context
allow corretto-8 slowdebug build.

### How has this been tested?
yes, validated here.
https://jenkins.finch.aws.a2z.com/view/nightly/job/corretto-8-official/10/

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context
https://bugs.openjdk.java.net/browse/JDK-8062808


### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
