### PR TITLE
8231209: [REDO] ThreadMXBean::getThreadAllocatedBytes() can be quicke…

### DIFF
--- a/src/hotspot/src/share/vm/services/jmm.h
+++ b/src/hotspot/src/share/vm/services/jmm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,6 +243,9 @@ typedef struct jmmInterface_1_ {
   jobject      (JNICALL *GetMemoryPoolUsage)     (JNIEnv* env, jobject pool);
   jobject      (JNICALL *GetPeakMemoryPoolUsage) (JNIEnv* env, jobject pool);
 
+  jlong        (JNICALL *GetOneThreadAllocatedMemory)
+                                                 (JNIEnv *env,
+                                                  jlong thread_id);
   void         (JNICALL *GetThreadAllocatedMemory)
                                                  (JNIEnv *env,
                                                   jlongArray ids,

--- a/src/hotspot/src/share/vm/services/management.cpp
+++ b/src/hotspot/src/share/vm/services/management.cpp
@@ -2206,6 +2206,30 @@ jlong Management::ticks_to_ms(jlong ticks) {
 }
 #endif // INCLUDE_MANAGEMENT
 
+// Gets the amount of memory allocated on the Java heap for a single thread.
+// Returns -1 if the thread does not exist or has terminated.
+JVM_ENTRY(jlong, jmm_GetOneThreadAllocatedMemory(JNIEnv *env, jlong thread_id))
+  if (thread_id < 0) {
+    THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
+               "Invalid thread ID", -1);
+  }
+
+  if (thread_id == 0) {
+    // current thread
+    if (THREAD->is_Java_thread()) {
+      return ((JavaThread*)THREAD)->cooked_allocated_bytes();
+    }
+    return -1;
+  }
+
+  MutexLockerEx ml(Threads_lock);
+  JavaThread* java_thread = Threads::find_java_thread_from_java_tid(thread_id);
+  if (java_thread != NULL) {
+    return java_thread->cooked_allocated_bytes();
+  }
+  return -1;
+JVM_END
+
 // Gets an array containing the amount of memory allocated on the Java
 // heap for a set of threads (in bytes).  Each element of the array is
 // the amount of memory allocated for the thread ID specified in the
@@ -2332,6 +2356,7 @@ const struct jmmInterface_1_ jmm_interface = {
   jmm_GetMemoryManagers,
   jmm_GetMemoryPoolUsage,
   jmm_GetPeakMemoryPoolUsage,
+  jmm_GetOneThreadAllocatedMemory,
   jmm_GetThreadAllocatedMemory,
   jmm_GetMemoryUsage,
   jmm_GetLongAttribute,

--- a/src/jdk/make/mapfiles/libmanagement/mapfile-vers
+++ b/src/jdk/make/mapfiles/libmanagement/mapfile-vers
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -83,6 +83,7 @@ SUNWprivate_1.1 {
 	    Java_sun_management_ThreadImpl_getThreadTotalCpuTime1;
 	    Java_sun_management_ThreadImpl_getThreadUserCpuTime0;
 	    Java_sun_management_ThreadImpl_getThreadUserCpuTime1;
+	    Java_sun_management_ThreadImpl_getThreadAllocatedMemory0;
 	    Java_sun_management_ThreadImpl_getThreadAllocatedMemory1;
 	    Java_sun_management_ThreadImpl_resetContentionTimes0;
 	    Java_sun_management_ThreadImpl_resetPeakThreadCount0;

--- a/src/jdk/src/share/classes/com/sun/management/ThreadMXBean.java
+++ b/src/jdk/src/share/classes/com/sun/management/ThreadMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @throws NullPointerException if {@code ids} is {@code null}
      * @throws IllegalArgumentException if any element in the input array
      *         {@code ids} is {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      *         virtual machine implementation does not support CPU time
      *         measurement.
      *
@@ -96,7 +96,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @throws NullPointerException if {@code ids} is {@code null}
      * @throws IllegalArgumentException if any element in the input array
      *         {@code ids} is {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      *         virtual machine implementation does not support CPU time
      *         measurement.
      *
@@ -110,13 +110,50 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
 
     /**
      * Returns an approximation of the total amount of memory, in bytes,
-     * allocated in heap memory for the thread of the specified ID.
+     * allocated in heap memory for the current thread.
+     * The returned value is an approximation because some Java virtual machine
+     * implementations may use object allocation mechanisms that result in a
+     * delay between the time an object is allocated and the time its size is
+     * recorded.
+     *
+     * <p>
+     * This is a convenience method for local management use and is
+     * equivalent to calling:
+     * <blockquote><pre>
+     *   {@link #getThreadAllocatedBytes getThreadAllocatedBytes}(Thread.currentThread().getId());
+     * </pre></blockquote>
+     *
+     * @implSpec The default implementation throws
+     * {@code UnsupportedOperationException}.
+     *
+     * @return an approximation of the total memory allocated, in bytes, in
+     * heap memory for the current thread
+     * if thread memory allocation measurement is enabled;
+     * {@code -1} otherwise.
+     *
+     * @throws UnsupportedOperationException if the Java virtual
+     *         machine implementation does not support thread memory allocation
+     *         measurement.
+     *
+     * @see #isThreadAllocatedMemorySupported
+     * @see #isThreadAllocatedMemoryEnabled
+     * @see #setThreadAllocatedMemoryEnabled
+     *
+     * @since 14
+     */
+    public default long getCurrentThreadAllocatedBytes() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns an approximation of the total amount of memory, in bytes,
+     * allocated in heap memory for the thread with the specified ID.
      * The returned value is an approximation because some Java virtual machine
      * implementations may use object allocation mechanisms that result in a
      * delay between the time an object is allocated and the time its size is
      * recorded.
      * <p>
-     * If the thread of the specified ID is not alive or does not exist,
+     * If the thread with the specified ID is not alive or does not exist,
      * this method returns {@code -1}. If thread memory allocation measurement
      * is disabled, this method returns {@code -1}.
      * A thread is alive if it has been started and has not yet died.
@@ -128,13 +165,13 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      *
      * @param id the thread ID of a thread
      * @return an approximation of the total memory allocated, in bytes, in
-     * heap memory for a thread of the specified ID
-     * if the thread of the specified ID exists, the thread is alive,
+     * heap memory for the thread with the specified ID
+     * if the thread with the specified ID exists, the thread is alive,
      * and thread memory allocation measurement is enabled;
      * {@code -1} otherwise.
      *
      * @throws IllegalArgumentException if {@code id} {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine implementation does not support thread memory allocation
      *         measurement.
      *
@@ -166,7 +203,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @throws NullPointerException if {@code ids} is {@code null}
      * @throws IllegalArgumentException if any element in the input array
      *         {@code ids} is {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine implementation does not support thread memory allocation
      *         measurement.
      *
@@ -195,7 +232,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @return {@code true} if thread memory allocation measurement is enabled;
      *         {@code false} otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine does not support thread memory allocation measurement.
      *
      * @see #isThreadAllocatedMemorySupported
@@ -209,10 +246,10 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @param enable {@code true} to enable;
      *               {@code false} to disable.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine does not support thread memory allocation measurement.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *

--- a/src/jdk/src/share/classes/java/lang/management/ThreadMXBean.java
+++ b/src/jdk/src/share/classes/java/lang/management/ThreadMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,7 +160,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @return an array of <tt>long</tt>, each is a thread ID.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      */
@@ -199,7 +199,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * it does not exist.
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      */
@@ -237,7 +237,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @throws IllegalArgumentException if any element in the input array
      *         <tt>ids</tt> is {@code <= 0}.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      */
@@ -284,7 +284,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
      * @throws IllegalArgumentException if <tt>maxDepth is negative</tt>.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      *
@@ -337,7 +337,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @throws IllegalArgumentException if <tt>maxDepth is negative</tt>.
      * @throws IllegalArgumentException if any element in the input array
      *      <tt>ids</tt> is {@code <= 0}.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      *
@@ -360,7 +360,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return <tt>true</tt> if thread contention monitoring is enabled;
      *         <tt>false</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      * machine does not support thread contention monitoring.
      *
      * @see #isThreadContentionMonitoringSupported
@@ -374,10 +374,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @param enable <tt>true</tt> to enable;
      *               <tt>false</tt> to disable.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support thread contention monitoring.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *
@@ -403,7 +403,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return the total CPU time for the current thread if CPU time
      * measurement is enabled; <tt>-1</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * the current thread.
      *
@@ -430,7 +430,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return the user-level CPU time for the current thread if CPU time
      * measurement is enabled; <tt>-1</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * the current thread.
      *
@@ -467,7 +467,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * <tt>-1</tt> otherwise.
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * other threads.
      *
@@ -502,7 +502,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * <tt>-1</tt> otherwise.
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * other threads.
      *
@@ -548,7 +548,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return <tt>true</tt> if thread CPU time measurement is enabled;
      *         <tt>false</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      * machine does not support CPU time measurement for other threads
      * nor for the current thread.
      *
@@ -564,11 +564,11 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @param enable <tt>true</tt> to enable;
      *               <tt>false</tt> to disable.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * any threads nor for the current thread.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *
@@ -604,7 +604,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return an array of IDs of the threads that are monitor
      * deadlocked, if any; <tt>null</tt> otherwise.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      *
@@ -616,7 +616,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * Resets the peak thread count to the current number of
      * live threads.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *
@@ -642,10 +642,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * deadlocked waiting for object monitors or ownable synchronizers, if any;
      * <tt>null</tt> otherwise.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      * machine does not support monitoring of ownable synchronizer usage.
      *
      * @see #isSynchronizerUsageSupported
@@ -743,10 +743,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * information about a thread whose ID is in the corresponding
      * element of the input array of IDs.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
-     * @throws java.lang.UnsupportedOperationException
+     * @throws UnsupportedOperationException
      *         <ul>
      *           <li>if <tt>lockedMonitors</tt> is <tt>true</tt> but
      *               the Java virtual machine does not support monitoring
@@ -782,10 +782,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @return an array of {@link ThreadInfo} for all live threads.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
-     * @throws java.lang.UnsupportedOperationException
+     * @throws UnsupportedOperationException
      *         <ul>
      *           <li>if <tt>lockedMonitors</tt> is <tt>true</tt> but
      *               the Java virtual machine does not support monitoring

--- a/src/jdk/src/share/classes/sun/management/ThreadImpl.java
+++ b/src/jdk/src/share/classes/sun/management/ThreadImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,9 @@
 package sun.management;
 
 import java.lang.management.ManagementFactory;
-
 import java.lang.management.ThreadInfo;
-
 import javax.management.ObjectName;
+import java.util.Objects;
 
 /**
  * Implementation class for the thread subsystem.
@@ -105,11 +104,15 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
         return cpuTimeEnabled;
     }
 
-    public boolean isThreadAllocatedMemoryEnabled() {
+    private void ensureThreadAllocatedMemorySupported() {
         if (!isThreadAllocatedMemorySupported()) {
             throw new UnsupportedOperationException(
-                "Thread allocated memory measurement is not supported");
+                "Thread allocated memory measurement is not supported.");
         }
+    }
+
+    public boolean isThreadAllocatedMemoryEnabled() {
+        ensureThreadAllocatedMemorySupported();
         return allocatedMemoryEnabled;
     }
 
@@ -144,16 +147,18 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
         return getThreadInfo(ids, 0);
     }
 
-    private void verifyThreadIds(long[] ids) {
-        if (ids == null) {
-            throw new NullPointerException("Null ids parameter.");
+    private void verifyThreadId(long id) {
+        if (id <= 0) {
+            throw new IllegalArgumentException(
+                "Invalid thread ID parameter: " + id);
         }
+    }
+
+    private void verifyThreadIds(long[] ids) {
+        Objects.requireNonNull(ids);
 
         for (int i = 0; i < ids.length; i++) {
-            if (ids[i] <= 0) {
-                throw new IllegalArgumentException(
-                    "Invalid thread ID parameter: " + ids[i]);
-            }
+            verifyThreadId(ids[i]);
         }
     }
 
@@ -324,26 +329,41 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
         }
     }
 
+    public long getCurrentThreadAllocatedBytes() {
+        if (isThreadAllocatedMemoryEnabled()) {
+            return getThreadAllocatedMemory0(0);
+        }
+        return -1;
+    }
+
+    private boolean verifyThreadAllocatedMemory(long id) {
+        verifyThreadId(id);
+        return isThreadAllocatedMemoryEnabled();
+    }
+
     public long getThreadAllocatedBytes(long id) {
-        long[] ids = new long[1];
-        ids[0] = id;
-        final long[] sizes = getThreadAllocatedBytes(ids);
-        return sizes[0];
+        boolean verified = verifyThreadAllocatedMemory(id);
+
+        if (verified) {
+            return getThreadAllocatedMemory0(
+                Thread.currentThread().getId() == id ? 0 : id);
+        }
+        return -1;
     }
 
     private boolean verifyThreadAllocatedMemory(long[] ids) {
         verifyThreadIds(ids);
-
-        // check if Thread allocated memory measurement is supported.
-        if (!isThreadAllocatedMemorySupported()) {
-            throw new UnsupportedOperationException(
-                "Thread allocated memory measurement is not supported.");
-        }
-
         return isThreadAllocatedMemoryEnabled();
     }
 
     public long[] getThreadAllocatedBytes(long[] ids) {
+        Objects.requireNonNull(ids);
+
+        if (ids.length == 1) {
+            long size = getThreadAllocatedBytes(ids[0]);
+            return new long[] { size };
+        }
+
         boolean verified = verifyThreadAllocatedMemory(ids);
 
         long[] sizes = new long[ids.length];
@@ -356,10 +376,7 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
     }
 
     public void setThreadAllocatedMemoryEnabled(boolean enable) {
-        if (!isThreadAllocatedMemorySupported()) {
-            throw new UnsupportedOperationException(
-                "Thread allocated memory measurement is not supported.");
-        }
+        ensureThreadAllocatedMemorySupported();
 
         Util.checkControlAccess();
         synchronized (this) {
@@ -463,6 +480,7 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
     private static native void getThreadTotalCpuTime1(long[] ids, long[] result);
     private static native long getThreadUserCpuTime0(long id);
     private static native void getThreadUserCpuTime1(long[] ids, long[] result);
+    private static native long getThreadAllocatedMemory0(long id);
     private static native void getThreadAllocatedMemory1(long[] ids, long[] result);
     private static native void setThreadCpuTimeEnabled0(boolean enable);
     private static native void setThreadAllocatedMemoryEnabled0(boolean enable);

--- a/src/jdk/src/share/javavm/export/jmm.h
+++ b/src/jdk/src/share/javavm/export/jmm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,6 +243,9 @@ typedef struct jmmInterface_1_ {
   jobject      (JNICALL *GetMemoryPoolUsage)     (JNIEnv* env, jobject pool);
   jobject      (JNICALL *GetPeakMemoryPoolUsage) (JNIEnv* env, jobject pool);
 
+  jlong        (JNICALL *GetOneThreadAllocatedMemory)
+                                                 (JNIEnv *env,
+                                                  jlong thread_id);
   void         (JNICALL *GetThreadAllocatedMemory)
                                                  (JNIEnv *env,
                                                   jlongArray ids,

--- a/src/jdk/src/share/native/sun/management/ThreadImpl.c
+++ b/src/jdk/src/share/native/sun/management/ThreadImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,6 +92,13 @@ Java_sun_management_ThreadImpl_getThreadUserCpuTime1
 {
     jmm_interface->GetThreadCpuTimesWithKind(env, ids, timeArray,
                                              JNI_FALSE /* user */);
+}
+
+JNIEXPORT jlong JNICALL
+Java_sun_management_ThreadImpl_getThreadAllocatedMemory0
+  (JNIEnv *env, jclass cls, jlong tid)
+{
+  return jmm_interface->GetOneThreadAllocatedMemory(env, tid);
 }
 
 JNIEXPORT void JNICALL

--- a/src/jdk/test/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
+++ b/src/jdk/test/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug     6173675
+ * @bug     6173675 8231209
  * @summary Basic test of ThreadMXBean.getThreadAllocatedBytes
  * @author  Paul Hohensee
  */
@@ -33,9 +33,8 @@ import java.lang.management.*;
 public class ThreadAllocatedMemory {
     private static com.sun.management.ThreadMXBean mbean =
         (com.sun.management.ThreadMXBean)ManagementFactory.getThreadMXBean();
-    private static boolean testFailed = false;
-    private static boolean done = false;
-    private static boolean done1 = false;
+    private static volatile boolean done = false;
+    private static volatile boolean done1 = false;
     private static Object obj = new Object();
     private static final int NUM_THREADS = 10;
     private static Thread[] threads = new Thread[NUM_THREADS];
@@ -44,6 +43,22 @@ public class ThreadAllocatedMemory {
     public static void main(String[] argv)
         throws Exception {
 
+        testSupportEnableDisable();
+
+        // Test current thread two ways
+        testGetCurrentThreadAllocatedBytes();
+        testCurrentThreadGetThreadAllocatedBytes();
+
+        // Test a single thread that is not this one
+        testGetThreadAllocatedBytes();
+
+        // Test many threads that are not this one
+        testGetThreadsAllocatedBytes();
+
+        System.out.println("Test passed");
+    }
+
+    private static void testSupportEnableDisable() {
         if (!mbean.isThreadAllocatedMemorySupported()) {
             return;
         }
@@ -58,10 +73,7 @@ public class ThreadAllocatedMemory {
                 "ThreadAllocatedMemory is expected to be disabled");
         }
 
-        Thread curThread = Thread.currentThread();
-        long id = curThread.getId();
-
-        long s = mbean.getThreadAllocatedBytes(id);
+        long s = mbean.getCurrentThreadAllocatedBytes();
         if (s != -1) {
             throw new RuntimeException(
                 "Invalid ThreadAllocatedBytes returned = " +
@@ -77,63 +89,106 @@ public class ThreadAllocatedMemory {
             throw new RuntimeException(
                 "ThreadAllocatedMemory is expected to be enabled");
         }
+    }
 
-        long size = mbean.getThreadAllocatedBytes(id);
-        // implementation could have started measurement when
-        // measurement was enabled, in which case size can be 0
-        if (size < 0) {
-            throw new RuntimeException(
-                "Invalid allocated bytes returned = " + size);
-        }
+    private static void testGetCurrentThreadAllocatedBytes() {
+        long size = mbean.getCurrentThreadAllocatedBytes();
+        ensureValidSize(size);
 
+        // do some more allocation
         doit();
 
-        // Expected to be size1 >= size
-        long size1 = mbean.getThreadAllocatedBytes(id);
-        if (size1 < size) {
-            throw new RuntimeException("Allocated bytes " + size1 +
-                " expected >= " + size);
-        }
-        System.out.println(curThread.getName() +
-            " Current thread allocated bytes = " + size +
-            " allocated bytes = " + size1);
+        checkResult(Thread.currentThread(), size,
+                    mbean.getCurrentThreadAllocatedBytes());
+    }
 
+    private static void testCurrentThreadGetThreadAllocatedBytes() {
+        Thread curThread = Thread.currentThread();
+        long id = curThread.getId();
 
-        // start threads, wait for them to block
-        for (int i = 0; i < NUM_THREADS; i++) {
-            threads[i] = new MyThread("MyThread-" + i);
-            threads[i].start();
-        }
+        long size = mbean.getThreadAllocatedBytes(id);
+        ensureValidSize(size);
 
-        // threads block after doing some allocation
-        waitUntilThreadBlocked();
+        // do some more allocation
+        doit();
 
-        for (int i = 0; i < NUM_THREADS; i++) {
-            sizes[i] = mbean.getThreadAllocatedBytes(threads[i].getId());
-        }
+        checkResult(curThread, size, mbean.getThreadAllocatedBytes(id));
+    }
 
-        // let threads go and do some more allocation
+    private static void testGetThreadAllocatedBytes()
+        throws Exception {
+
+        // start a thread
+        done = false; done1 = false;
+        Thread curThread = new MyThread("MyThread");
+        curThread.start();
+        long id = curThread.getId();
+
+        // wait for thread to block after doing some allocation
+        waitUntilThreadBlocked(curThread);
+
+        long size = mbean.getThreadAllocatedBytes(id);
+        ensureValidSize(size);
+
+        // let thread go to do some more allocation
         synchronized (obj) {
             done = true;
             obj.notifyAll();
         }
 
-        // wait for threads to get going again.  we don't care if we
+        // wait for thread to get going again. we don't care if we
+        // catch it in mid-execution or if it hasn't
+        // restarted after we're done sleeping.
+        goSleep(400);
+
+        checkResult(curThread, size, mbean.getThreadAllocatedBytes(id));
+
+        // let thread exit
+        synchronized (obj) {
+            done1 = true;
+            obj.notifyAll();
+        }
+
+        try {
+            curThread.join();
+        } catch (InterruptedException e) {
+            System.out.println("Unexpected exception is thrown.");
+            e.printStackTrace(System.out);
+        }
+    }
+
+    private static void testGetThreadsAllocatedBytes()
+        throws Exception {
+
+        // start threads
+        done = false; done1 = false;
+        for (int i = 0; i < NUM_THREADS; i++) {
+            threads[i] = new MyThread("MyThread-" + i);
+            threads[i].start();
+        }
+
+        // wait for threads to block after doing some allocation
+        waitUntilThreadsBlocked();
+
+        for (int i = 0; i < NUM_THREADS; i++) {
+            sizes[i] = mbean.getThreadAllocatedBytes(threads[i].getId());
+            ensureValidSize(sizes[i]);
+        }
+
+        // let threads go to do some more allocation
+        synchronized (obj) {
+            done = true;
+            obj.notifyAll();
+        }
+
+        // wait for threads to get going again. we don't care if we
         // catch them in mid-execution or if some of them haven't
         // restarted after we're done sleeping.
         goSleep(400);
 
         for (int i = 0; i < NUM_THREADS; i++) {
-            long newSize = mbean.getThreadAllocatedBytes(threads[i].getId());
-            if (sizes[i] > newSize) {
-                throw new RuntimeException("TEST FAILED: " +
-                    threads[i].getName() +
-                    " previous allocated bytes = " + sizes[i] +
-                    " > current allocated bytes = " + newSize);
-            }
-            System.out.println(threads[i].getName() +
-                " Previous allocated bytes = " + sizes[i] +
-                " Current allocated bytes = " + newSize);
+            checkResult(threads[i], sizes[i],
+                        mbean.getThreadAllocatedBytes(threads[i].getId()));
         }
 
         // let threads exit
@@ -148,17 +203,30 @@ public class ThreadAllocatedMemory {
             } catch (InterruptedException e) {
                 System.out.println("Unexpected exception is thrown.");
                 e.printStackTrace(System.out);
-                testFailed = true;
                 break;
             }
         }
-        if (testFailed) {
-            throw new RuntimeException("TEST FAILED");
-        }
-
-        System.out.println("Test passed");
     }
 
+    private static void ensureValidSize(long size) {
+        // implementation could have started measurement when
+        // measurement was enabled, in which case size can be 0
+        if (size < 0) {
+            throw new RuntimeException(
+                "Invalid allocated bytes returned = " + size);
+        }
+    }
+
+    private static void checkResult(Thread curThread,
+                                    long prev_size, long curr_size) {
+        if (curr_size < prev_size) {
+            throw new RuntimeException("Allocated bytes " + curr_size +
+                                       " expected >= " + prev_size);
+        }
+        System.out.println(curThread.getName() +
+                           " Previous allocated bytes = " + prev_size +
+                           " Current allocated bytes = " + curr_size);
+    }
 
     private static void goSleep(long ms) throws Exception {
         try {
@@ -169,7 +237,18 @@ public class ThreadAllocatedMemory {
         }
     }
 
-    private static void waitUntilThreadBlocked()
+    private static void waitUntilThreadBlocked(Thread thread)
+        throws Exception {
+        while (true) {
+            goSleep(100);
+            ThreadInfo info = mbean.getThreadInfo(thread.getId());
+            if (info.getThreadState() == Thread.State.WAITING) {
+                break;
+            }
+        }
+    }
+
+    private static void waitUntilThreadsBlocked()
         throws Exception {
         int count = 0;
         while (count != NUM_THREADS) {
@@ -210,7 +289,6 @@ public class ThreadAllocatedMemory {
                     } catch (InterruptedException e) {
                         System.out.println("Unexpected exception is thrown.");
                         e.printStackTrace(System.out);
-                        testFailed = true;
                         break;
                     }
                 }
@@ -225,7 +303,7 @@ public class ThreadAllocatedMemory {
                 " ThreadAllocatedBytes  = " + size2);
 
             if (size1 > size2) {
-                throw new RuntimeException("TEST FAILED: " + getName() +
+                throw new RuntimeException(getName() +
                     " ThreadAllocatedBytes = " + size1 +
                     " > ThreadAllocatedBytes = " + size2);
             }
@@ -237,7 +315,6 @@ public class ThreadAllocatedMemory {
                     } catch (InterruptedException e) {
                         System.out.println("Unexpected exception is thrown.");
                         e.printStackTrace(System.out);
-                        testFailed = true;
                         break;
                     }
                 }


### PR DESCRIPTION
### Description
Backport 8231209 from OpenJDK jdk project tip. Commit message from that push:

8231209: [REDO] JDK-8207266 ThreadMXBean::getThreadAllocatedBytes() can be quicker for self thread
Summary: Add com.sun.management.getCurrentThreadAllocatedBytes, implement getThreadAllocatedBytes(long) independent of getThreadAllocatedBytes(long[])
Reviewed-by: mchung, dholmes, sspitsyn

See

https://bugs.openjdk.java.net/browse/JDK-8231209
https://bugs.openjdk.java.net/browse/JDK-8207266

8231209 patch: https://hg.openjdk.java.net/jdk/jdk/rev/c29e49148be7

The patch did not apply cleanly because the MXBean class heirarchy and build system are different in jdk tip. Also, there are no nsk tests in jdk8u, so changes to those files do not apply.

### Related issues

### Motivation and context
Drastically reduce the cost of calling getThreadAllocatedBytes on the current thread and eliminate object allocation in getThreadAllocatedBytes(long). getCurrentThreadAllocatedBytes() now reduces to the equivalent of getThreadAllocatedBytes(Thread.currentThread().getId()).

### How has this been tested?
jdk/test/com/sun/management jtreg tests pass.


### Platform information
    Works on OS: Any
    Applies to version 8u232


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
