### PR TITLE
Backport of 8146238: [macosx] Java2D Queue Flusher crash on OSX after switching between user accounts

### DIFF
--- a/src/hotspot/src/share/vm/services/jmm.h
+++ b/src/hotspot/src/share/vm/services/jmm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,6 +243,9 @@ typedef struct jmmInterface_1_ {
   jobject      (JNICALL *GetMemoryPoolUsage)     (JNIEnv* env, jobject pool);
   jobject      (JNICALL *GetPeakMemoryPoolUsage) (JNIEnv* env, jobject pool);
 
+  jlong        (JNICALL *GetOneThreadAllocatedMemory)
+                                                 (JNIEnv *env,
+                                                  jlong thread_id);
   void         (JNICALL *GetThreadAllocatedMemory)
                                                  (JNIEnv *env,
                                                   jlongArray ids,

--- a/src/hotspot/src/share/vm/services/management.cpp
+++ b/src/hotspot/src/share/vm/services/management.cpp
@@ -2206,6 +2206,30 @@ jlong Management::ticks_to_ms(jlong ticks) {
 }
 #endif // INCLUDE_MANAGEMENT
 
+// Gets the amount of memory allocated on the Java heap for a single thread.
+// Returns -1 if the thread does not exist or has terminated.
+JVM_ENTRY(jlong, jmm_GetOneThreadAllocatedMemory(JNIEnv *env, jlong thread_id))
+  if (thread_id < 0) {
+    THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
+               "Invalid thread ID", -1);
+  }
+
+  if (thread_id == 0) {
+    // current thread
+    if (THREAD->is_Java_thread()) {
+      return ((JavaThread*)THREAD)->cooked_allocated_bytes();
+    }
+    return -1;
+  }
+
+  MutexLockerEx ml(Threads_lock);
+  JavaThread* java_thread = Threads::find_java_thread_from_java_tid(thread_id);
+  if (java_thread != NULL) {
+    return java_thread->cooked_allocated_bytes();
+  }
+  return -1;
+JVM_END
+
 // Gets an array containing the amount of memory allocated on the Java
 // heap for a set of threads (in bytes).  Each element of the array is
 // the amount of memory allocated for the thread ID specified in the
@@ -2332,6 +2356,7 @@ const struct jmmInterface_1_ jmm_interface = {
   jmm_GetMemoryManagers,
   jmm_GetMemoryPoolUsage,
   jmm_GetPeakMemoryPoolUsage,
+  jmm_GetOneThreadAllocatedMemory,
   jmm_GetThreadAllocatedMemory,
   jmm_GetMemoryUsage,
   jmm_GetLongAttribute,

--- a/src/jdk/make/mapfiles/libmanagement/mapfile-vers
+++ b/src/jdk/make/mapfiles/libmanagement/mapfile-vers
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -83,6 +83,7 @@ SUNWprivate_1.1 {
 	    Java_sun_management_ThreadImpl_getThreadTotalCpuTime1;
 	    Java_sun_management_ThreadImpl_getThreadUserCpuTime0;
 	    Java_sun_management_ThreadImpl_getThreadUserCpuTime1;
+	    Java_sun_management_ThreadImpl_getThreadAllocatedMemory0;
 	    Java_sun_management_ThreadImpl_getThreadAllocatedMemory1;
 	    Java_sun_management_ThreadImpl_resetContentionTimes0;
 	    Java_sun_management_ThreadImpl_resetPeakThreadCount0;

--- a/src/jdk/src/macosx/classes/sun/java2d/opengl/CGLSurfaceData.java
+++ b/src/jdk/src/macosx/classes/sun/java2d/opengl/CGLSurfaceData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,8 +48,9 @@ public abstract class CGLSurfaceData extends OGLSurfaceData {
 
     native void validate(int xoff, int yoff, int width, int height, boolean isOpaque);
 
-    private native void initOps(long pConfigInfo, long pPeerData, long layerPtr,
-                                int xoff, int yoff, boolean isOpaque);
+    private native void initOps(OGLGraphicsConfig gc, long pConfigInfo,
+                                long pPeerData, long layerPtr, int xoff,
+                                int yoff, boolean isOpaque);
 
     protected native boolean initPbuffer(long pData, long pConfigInfo,
             boolean isOpaque, int width, int height);
@@ -77,7 +78,7 @@ public abstract class CGLSurfaceData extends OGLSurfaceData {
             pPeerData = pView.getAWTView();
             isOpaque = pView.isOpaque();
         }
-        initOps(pConfigInfo, pPeerData, 0, 0, 0, isOpaque);
+        initOps(gc, pConfigInfo, pPeerData, 0, 0, 0, isOpaque);
     }
 
     protected CGLSurfaceData(CGLLayer layer, CGLGraphicsConfig gc,
@@ -93,7 +94,7 @@ public abstract class CGLSurfaceData extends OGLSurfaceData {
             layerPtr = layer.getPointer();
             isOpaque = layer.isOpaque();
         }
-        initOps(pConfigInfo, 0, layerPtr, 0, 0, isOpaque);
+        initOps(gc, pConfigInfo, 0, layerPtr, 0, 0, isOpaque);
     }
 
     @Override //SurfaceData

--- a/src/jdk/src/macosx/native/sun/java2d/opengl/CGLSurfaceData.m
+++ b/src/jdk/src/macosx/native/sun/java2d/opengl/CGLSurfaceData.m
@@ -145,31 +145,6 @@ JNF_COCOA_EXIT(env);
 }
 
 /**
- * Returns a pointer (as a jlong) to the native CGLGraphicsConfigInfo
- * associated with the given OGLSDOps.  This method can be called from
- * shared code to retrieve the native GraphicsConfig data in a platform-
- * independent manner.
- */
-jlong
-OGLSD_GetNativeConfigInfo(OGLSDOps *oglsdo)
-{
-    J2dTraceLn(J2D_TRACE_INFO, "OGLSD_GetNativeConfigInfo");
-
-    if (oglsdo == NULL) {
-        J2dRlsTraceLn(J2D_TRACE_ERROR, "OGLSD_GetNativeConfigInfo: ops are null");
-        return 0L;
-    }
-
-    CGLSDOps *cglsdo = (CGLSDOps *)oglsdo->privOps;
-    if (cglsdo == NULL) {
-        J2dRlsTraceLn(J2D_TRACE_ERROR, "OGLSD_GetNativeConfigInfo: cgl ops are null");
-        return 0L;
-    }
-
-    return ptr_to_jlong(cglsdo->configInfo);
-}
-
-/**
  * Makes the given GraphicsConfig's context current to its associated
  * "scratch" surface.  If there is a problem making the context current,
  * this method will return NULL; otherwise, returns a pointer to the
@@ -411,7 +386,7 @@ extern DisposeFunc     OGLSD_Dispose;
 
 JNIEXPORT void JNICALL
 Java_sun_java2d_opengl_CGLSurfaceData_initOps
-    (JNIEnv *env, jobject cglsd,
+    (JNIEnv *env, jobject cglsd, jobject gc,
      jlong pConfigInfo, jlong pPeerData, jlong layerPtr,
      jint xoff, jint yoff, jboolean isOpaque)
 {
@@ -419,8 +394,22 @@ Java_sun_java2d_opengl_CGLSurfaceData_initOps
     J2dTraceLn1(J2D_TRACE_INFO, "  pPeerData=%p", jlong_to_ptr(pPeerData));
     J2dTraceLn2(J2D_TRACE_INFO, "  xoff=%d, yoff=%d", (int)xoff, (int)yoff);
 
+    gc = (*env)->NewGlobalRef(env, gc);
+    if (gc == NULL) {
+        JNU_ThrowOutOfMemoryError(env, "Initialization of SurfaceData failed.");
+        return;
+    }
+
     OGLSDOps *oglsdo = (OGLSDOps *)
         SurfaceData_InitOps(env, cglsd, sizeof(OGLSDOps));
+    if (oglsdo == NULL) {
+        (*env)->DeleteGlobalRef(env, gc);
+        JNU_ThrowOutOfMemoryError(env, "Initialization of SurfaceData failed.");
+        return;
+    }
+    // later the graphicsConfig will be used for deallocation of oglsdo
+    oglsdo->graphicsConfig = gc;
+
     CGLSDOps *cglsdo = (CGLSDOps *)malloc(sizeof(CGLSDOps));
     if (cglsdo == NULL) {
         JNU_ThrowOutOfMemoryError(env, "creating native cgl ops");

--- a/src/jdk/src/share/classes/com/sun/management/ThreadMXBean.java
+++ b/src/jdk/src/share/classes/com/sun/management/ThreadMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @throws NullPointerException if {@code ids} is {@code null}
      * @throws IllegalArgumentException if any element in the input array
      *         {@code ids} is {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      *         virtual machine implementation does not support CPU time
      *         measurement.
      *
@@ -96,7 +96,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @throws NullPointerException if {@code ids} is {@code null}
      * @throws IllegalArgumentException if any element in the input array
      *         {@code ids} is {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      *         virtual machine implementation does not support CPU time
      *         measurement.
      *
@@ -110,13 +110,50 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
 
     /**
      * Returns an approximation of the total amount of memory, in bytes,
-     * allocated in heap memory for the thread of the specified ID.
+     * allocated in heap memory for the current thread.
+     * The returned value is an approximation because some Java virtual machine
+     * implementations may use object allocation mechanisms that result in a
+     * delay between the time an object is allocated and the time its size is
+     * recorded.
+     *
+     * <p>
+     * This is a convenience method for local management use and is
+     * equivalent to calling:
+     * <blockquote><pre>
+     *   {@link #getThreadAllocatedBytes getThreadAllocatedBytes}(Thread.currentThread().getId());
+     * </pre></blockquote>
+     *
+     * @implSpec The default implementation throws
+     * {@code UnsupportedOperationException}.
+     *
+     * @return an approximation of the total memory allocated, in bytes, in
+     * heap memory for the current thread
+     * if thread memory allocation measurement is enabled;
+     * {@code -1} otherwise.
+     *
+     * @throws UnsupportedOperationException if the Java virtual
+     *         machine implementation does not support thread memory allocation
+     *         measurement.
+     *
+     * @see #isThreadAllocatedMemorySupported
+     * @see #isThreadAllocatedMemoryEnabled
+     * @see #setThreadAllocatedMemoryEnabled
+     *
+     * @since 14
+     */
+    public default long getCurrentThreadAllocatedBytes() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns an approximation of the total amount of memory, in bytes,
+     * allocated in heap memory for the thread with the specified ID.
      * The returned value is an approximation because some Java virtual machine
      * implementations may use object allocation mechanisms that result in a
      * delay between the time an object is allocated and the time its size is
      * recorded.
      * <p>
-     * If the thread of the specified ID is not alive or does not exist,
+     * If the thread with the specified ID is not alive or does not exist,
      * this method returns {@code -1}. If thread memory allocation measurement
      * is disabled, this method returns {@code -1}.
      * A thread is alive if it has been started and has not yet died.
@@ -128,13 +165,13 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      *
      * @param id the thread ID of a thread
      * @return an approximation of the total memory allocated, in bytes, in
-     * heap memory for a thread of the specified ID
-     * if the thread of the specified ID exists, the thread is alive,
+     * heap memory for the thread with the specified ID
+     * if the thread with the specified ID exists, the thread is alive,
      * and thread memory allocation measurement is enabled;
      * {@code -1} otherwise.
      *
      * @throws IllegalArgumentException if {@code id} {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine implementation does not support thread memory allocation
      *         measurement.
      *
@@ -166,7 +203,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @throws NullPointerException if {@code ids} is {@code null}
      * @throws IllegalArgumentException if any element in the input array
      *         {@code ids} is {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine implementation does not support thread memory allocation
      *         measurement.
      *
@@ -195,7 +232,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @return {@code true} if thread memory allocation measurement is enabled;
      *         {@code false} otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine does not support thread memory allocation measurement.
      *
      * @see #isThreadAllocatedMemorySupported
@@ -209,10 +246,10 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @param enable {@code true} to enable;
      *               {@code false} to disable.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine does not support thread memory allocation measurement.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *

--- a/src/jdk/src/share/classes/java/lang/management/ThreadMXBean.java
+++ b/src/jdk/src/share/classes/java/lang/management/ThreadMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,7 +160,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @return an array of <tt>long</tt>, each is a thread ID.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      */
@@ -199,7 +199,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * it does not exist.
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      */
@@ -237,7 +237,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @throws IllegalArgumentException if any element in the input array
      *         <tt>ids</tt> is {@code <= 0}.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      */
@@ -284,7 +284,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
      * @throws IllegalArgumentException if <tt>maxDepth is negative</tt>.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      *
@@ -337,7 +337,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @throws IllegalArgumentException if <tt>maxDepth is negative</tt>.
      * @throws IllegalArgumentException if any element in the input array
      *      <tt>ids</tt> is {@code <= 0}.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      *
@@ -360,7 +360,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return <tt>true</tt> if thread contention monitoring is enabled;
      *         <tt>false</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      * machine does not support thread contention monitoring.
      *
      * @see #isThreadContentionMonitoringSupported
@@ -374,10 +374,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @param enable <tt>true</tt> to enable;
      *               <tt>false</tt> to disable.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support thread contention monitoring.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *
@@ -403,7 +403,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return the total CPU time for the current thread if CPU time
      * measurement is enabled; <tt>-1</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * the current thread.
      *
@@ -430,7 +430,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return the user-level CPU time for the current thread if CPU time
      * measurement is enabled; <tt>-1</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * the current thread.
      *
@@ -467,7 +467,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * <tt>-1</tt> otherwise.
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * other threads.
      *
@@ -502,7 +502,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * <tt>-1</tt> otherwise.
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * other threads.
      *
@@ -548,7 +548,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return <tt>true</tt> if thread CPU time measurement is enabled;
      *         <tt>false</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      * machine does not support CPU time measurement for other threads
      * nor for the current thread.
      *
@@ -564,11 +564,11 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @param enable <tt>true</tt> to enable;
      *               <tt>false</tt> to disable.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * any threads nor for the current thread.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *
@@ -604,7 +604,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return an array of IDs of the threads that are monitor
      * deadlocked, if any; <tt>null</tt> otherwise.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      *
@@ -616,7 +616,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * Resets the peak thread count to the current number of
      * live threads.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *
@@ -642,10 +642,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * deadlocked waiting for object monitors or ownable synchronizers, if any;
      * <tt>null</tt> otherwise.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      * machine does not support monitoring of ownable synchronizer usage.
      *
      * @see #isSynchronizerUsageSupported
@@ -743,10 +743,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * information about a thread whose ID is in the corresponding
      * element of the input array of IDs.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
-     * @throws java.lang.UnsupportedOperationException
+     * @throws UnsupportedOperationException
      *         <ul>
      *           <li>if <tt>lockedMonitors</tt> is <tt>true</tt> but
      *               the Java virtual machine does not support monitoring
@@ -782,10 +782,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @return an array of {@link ThreadInfo} for all live threads.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
-     * @throws java.lang.UnsupportedOperationException
+     * @throws UnsupportedOperationException
      *         <ul>
      *           <li>if <tt>lockedMonitors</tt> is <tt>true</tt> but
      *               the Java virtual machine does not support monitoring

--- a/src/jdk/src/share/classes/sun/java2d/opengl/OGLSurfaceData.java
+++ b/src/jdk/src/share/classes/sun/java2d/opengl/OGLSurfaceData.java
@@ -27,6 +27,7 @@ package sun.java2d.opengl;
 
 import java.awt.AlphaComposite;
 import java.awt.Composite;
+import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
 import java.awt.Transparency;
@@ -598,16 +599,16 @@ public abstract class OGLSurfaceData extends SurfaceData
      * (referenced by the pData parameter).  This method is invoked from
      * the native Dispose() method from the Disposer thread when the
      * Java-level OGLSurfaceData object is about to go away.  Note that we
-     * also pass a reference to the native GLX/WGLGraphicsConfigInfo
-     * (pConfigInfo) for the purposes of making a context current.
+     * also pass a reference to the OGLGraphicsConfig
+     * for the purposes of making a context current.
      */
-    static void dispose(long pData, long pConfigInfo) {
+    static void dispose(long pData, OGLGraphicsConfig gc) {
         OGLRenderQueue rq = OGLRenderQueue.getInstance();
         rq.lock();
         try {
             // make sure we have a current context before
             // disposing the native resources (e.g. texture object)
-            OGLContext.setScratchSurface(pConfigInfo);
+            OGLContext.setScratchSurface(gc);
 
             RenderBuffer buf = rq.getBuffer();
             rq.ensureCapacityAndAlignment(12, 4);

--- a/src/jdk/src/share/classes/sun/management/ThreadImpl.java
+++ b/src/jdk/src/share/classes/sun/management/ThreadImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,9 @@
 package sun.management;
 
 import java.lang.management.ManagementFactory;
-
 import java.lang.management.ThreadInfo;
-
 import javax.management.ObjectName;
+import java.util.Objects;
 
 /**
  * Implementation class for the thread subsystem.
@@ -105,11 +104,15 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
         return cpuTimeEnabled;
     }
 
-    public boolean isThreadAllocatedMemoryEnabled() {
+    private void ensureThreadAllocatedMemorySupported() {
         if (!isThreadAllocatedMemorySupported()) {
             throw new UnsupportedOperationException(
-                "Thread allocated memory measurement is not supported");
+                "Thread allocated memory measurement is not supported.");
         }
+    }
+
+    public boolean isThreadAllocatedMemoryEnabled() {
+        ensureThreadAllocatedMemorySupported();
         return allocatedMemoryEnabled;
     }
 
@@ -144,16 +147,18 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
         return getThreadInfo(ids, 0);
     }
 
-    private void verifyThreadIds(long[] ids) {
-        if (ids == null) {
-            throw new NullPointerException("Null ids parameter.");
+    private void verifyThreadId(long id) {
+        if (id <= 0) {
+            throw new IllegalArgumentException(
+                "Invalid thread ID parameter: " + id);
         }
+    }
+
+    private void verifyThreadIds(long[] ids) {
+        Objects.requireNonNull(ids);
 
         for (int i = 0; i < ids.length; i++) {
-            if (ids[i] <= 0) {
-                throw new IllegalArgumentException(
-                    "Invalid thread ID parameter: " + ids[i]);
-            }
+            verifyThreadId(ids[i]);
         }
     }
 
@@ -324,26 +329,41 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
         }
     }
 
+    public long getCurrentThreadAllocatedBytes() {
+        if (isThreadAllocatedMemoryEnabled()) {
+            return getThreadAllocatedMemory0(0);
+        }
+        return -1;
+    }
+
+    private boolean verifyThreadAllocatedMemory(long id) {
+        verifyThreadId(id);
+        return isThreadAllocatedMemoryEnabled();
+    }
+
     public long getThreadAllocatedBytes(long id) {
-        long[] ids = new long[1];
-        ids[0] = id;
-        final long[] sizes = getThreadAllocatedBytes(ids);
-        return sizes[0];
+        boolean verified = verifyThreadAllocatedMemory(id);
+
+        if (verified) {
+            return getThreadAllocatedMemory0(
+                Thread.currentThread().getId() == id ? 0 : id);
+        }
+        return -1;
     }
 
     private boolean verifyThreadAllocatedMemory(long[] ids) {
         verifyThreadIds(ids);
-
-        // check if Thread allocated memory measurement is supported.
-        if (!isThreadAllocatedMemorySupported()) {
-            throw new UnsupportedOperationException(
-                "Thread allocated memory measurement is not supported.");
-        }
-
         return isThreadAllocatedMemoryEnabled();
     }
 
     public long[] getThreadAllocatedBytes(long[] ids) {
+        Objects.requireNonNull(ids);
+
+        if (ids.length == 1) {
+            long size = getThreadAllocatedBytes(ids[0]);
+            return new long[] { size };
+        }
+
         boolean verified = verifyThreadAllocatedMemory(ids);
 
         long[] sizes = new long[ids.length];
@@ -356,10 +376,7 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
     }
 
     public void setThreadAllocatedMemoryEnabled(boolean enable) {
-        if (!isThreadAllocatedMemorySupported()) {
-            throw new UnsupportedOperationException(
-                "Thread allocated memory measurement is not supported.");
-        }
+        ensureThreadAllocatedMemorySupported();
 
         Util.checkControlAccess();
         synchronized (this) {
@@ -463,6 +480,7 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
     private static native void getThreadTotalCpuTime1(long[] ids, long[] result);
     private static native long getThreadUserCpuTime0(long id);
     private static native void getThreadUserCpuTime1(long[] ids, long[] result);
+    private static native long getThreadAllocatedMemory0(long id);
     private static native void getThreadAllocatedMemory1(long[] ids, long[] result);
     private static native void setThreadCpuTimeEnabled0(boolean enable);
     private static native void setThreadAllocatedMemoryEnabled0(boolean enable);

--- a/src/jdk/src/share/javavm/export/jmm.h
+++ b/src/jdk/src/share/javavm/export/jmm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,6 +243,9 @@ typedef struct jmmInterface_1_ {
   jobject      (JNICALL *GetMemoryPoolUsage)     (JNIEnv* env, jobject pool);
   jobject      (JNICALL *GetPeakMemoryPoolUsage) (JNIEnv* env, jobject pool);
 
+  jlong        (JNICALL *GetOneThreadAllocatedMemory)
+                                                 (JNIEnv *env,
+                                                  jlong thread_id);
   void         (JNICALL *GetThreadAllocatedMemory)
                                                  (JNIEnv *env,
                                                   jlongArray ids,

--- a/src/jdk/src/share/native/sun/java2d/opengl/OGLSurfaceData.c
+++ b/src/jdk/src/share/native/sun/java2d/opengl/OGLSurfaceData.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,6 @@
  * The following methods are implemented in the windowing system (i.e. GLX
  * and WGL) source files.
  */
-extern jlong OGLSD_GetNativeConfigInfo(OGLSDOps *oglsdo);
 extern jboolean OGLSD_InitOGLWindow(JNIEnv *env, OGLSDOps *oglsdo);
 extern void OGLSD_DestroyOGLSurface(JNIEnv *env, OGLSDOps *oglsdo);
 
@@ -593,11 +592,14 @@ void
 OGLSD_Dispose(JNIEnv *env, SurfaceDataOps *ops)
 {
     OGLSDOps *oglsdo = (OGLSDOps *)ops;
-    jlong pConfigInfo = OGLSD_GetNativeConfigInfo(oglsdo);
+    jobject graphicsConfig = oglsdo->graphicsConfig;
 
     JNU_CallStaticMethodByName(env, NULL, "sun/java2d/opengl/OGLSurfaceData",
-                               "dispose", "(JJ)V",
-                               ptr_to_jlong(ops), pConfigInfo);
+                               "dispose",
+                               "(JLsun/java2d/opengl/OGLGraphicsConfig;)V",
+                               ptr_to_jlong(ops), graphicsConfig);
+    (*env)->DeleteGlobalRef(env, graphicsConfig);
+    oglsdo->graphicsConfig = NULL;
 }
 
 /**

--- a/src/jdk/src/share/native/sun/java2d/opengl/OGLSurfaceData.h
+++ b/src/jdk/src/share/native/sun/java2d/opengl/OGLSurfaceData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,6 +85,9 @@ typedef struct {
  * Pointer to native-specific (GLX, WGL, etc.) SurfaceData info, such as the
  * native Drawable handle and GraphicsConfig data.
  *
+ *     jobject graphicsConfig;;
+ * Strong reference to the OGLGraphicsConfig used by this OGLSurfaceData.
+ *
  *     jint drawableType;
  * The surface type; can be any one of the surface type constants defined
  * below (OGLSD_WINDOW, OGLSD_TEXTURE, etc).
@@ -162,6 +165,7 @@ typedef struct {
 struct _OGLSDOps {
     SurfaceDataOps               sdOps;
     void                         *privOps;
+    jobject                      graphicsConfig;
     jint                         drawableType;
     GLenum                       activeBuffer;
     jboolean                     isOpaque;

--- a/src/jdk/src/share/native/sun/management/ThreadImpl.c
+++ b/src/jdk/src/share/native/sun/management/ThreadImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,6 +92,13 @@ Java_sun_management_ThreadImpl_getThreadUserCpuTime1
 {
     jmm_interface->GetThreadCpuTimesWithKind(env, ids, timeArray,
                                              JNI_FALSE /* user */);
+}
+
+JNIEXPORT jlong JNICALL
+Java_sun_management_ThreadImpl_getThreadAllocatedMemory0
+  (JNIEnv *env, jclass cls, jlong tid)
+{
+  return jmm_interface->GetOneThreadAllocatedMemory(env, tid);
 }
 
 JNIEXPORT void JNICALL

--- a/src/jdk/src/solaris/classes/sun/java2d/opengl/GLXSurfaceData.java
+++ b/src/jdk/src/solaris/classes/sun/java2d/opengl/GLXSurfaceData.java
@@ -41,7 +41,8 @@ public abstract class GLXSurfaceData extends OGLSurfaceData {
     protected X11ComponentPeer peer;
     private GLXGraphicsConfig graphicsConfig;
 
-    private native void initOps(X11ComponentPeer peer, long aData);
+    private native void initOps(OGLGraphicsConfig gc, X11ComponentPeer peer,
+                                long aData);
     protected native boolean initPbuffer(long pData, long pConfigInfo,
                                          boolean isOpaque,
                                          int width, int height);
@@ -52,7 +53,7 @@ public abstract class GLXSurfaceData extends OGLSurfaceData {
         super(gc, cm, type);
         this.peer = peer;
         this.graphicsConfig = gc;
-        initOps(peer, graphicsConfig.getAData());
+        initOps(gc, peer, graphicsConfig.getAData());
     }
 
     public GraphicsConfiguration getDeviceConfiguration() {

--- a/src/jdk/src/solaris/native/sun/java2d/opengl/GLXSurfaceData.c
+++ b/src/jdk/src/solaris/native/sun/java2d/opengl/GLXSurfaceData.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,21 +54,30 @@ jboolean surfaceCreationFailed = JNI_FALSE;
 
 JNIEXPORT void JNICALL
 Java_sun_java2d_opengl_GLXSurfaceData_initOps(JNIEnv *env, jobject glxsd,
+                                              jobject gc,
                                               jobject peer, jlong aData)
 {
 #ifndef HEADLESS
-    GLXSDOps *glxsdo = (GLXSDOps *)malloc(sizeof(GLXSDOps));
-
-    if (glxsdo == NULL) {
-        JNU_ThrowOutOfMemoryError(env, "creating native GLX ops");
+    gc = (*env)->NewGlobalRef(env, gc);
+    if (gc == NULL) {
+        JNU_ThrowOutOfMemoryError(env, "Initialization of SurfaceData failed.");
         return;
     }
 
     OGLSDOps *oglsdo = (OGLSDOps *)SurfaceData_InitOps(env, glxsd,
                                                        sizeof(OGLSDOps));
     if (oglsdo == NULL) {
-        free(glxsdo);
+        (*env)->DeleteGlobalRef(env, gc);
         JNU_ThrowOutOfMemoryError(env, "Initialization of SurfaceData failed.");
+        return;
+    }
+    // later the graphicsConfig will be used for deallocation of oglsdo
+    oglsdo->graphicsConfig = gc;
+
+    GLXSDOps *glxsdo = (GLXSDOps *)malloc(sizeof(GLXSDOps));
+
+    if (glxsdo == NULL) {
+        JNU_ThrowOutOfMemoryError(env, "creating native GLX ops");
         return;
     }
 
@@ -162,39 +171,6 @@ GLXSD_MakeCurrentToScratch(JNIEnv *env, OGLContext *oglc)
     }
 
     return JNI_TRUE;
-}
-
-/**
- * Returns a pointer (as a jlong) to the native GLXGraphicsConfigInfo
- * associated with the given OGLSDOps.  This method can be called from
- * shared code to retrieve the native GraphicsConfig data in a platform-
- * independent manner.
- */
-jlong
-OGLSD_GetNativeConfigInfo(OGLSDOps *oglsdo)
-{
-    GLXSDOps *glxsdo;
-
-    if (oglsdo == NULL) {
-        J2dRlsTraceLn(J2D_TRACE_ERROR,
-                      "OGLSD_GetNativeConfigInfo: ops are null");
-        return 0L;
-    }
-
-    glxsdo = (GLXSDOps *)oglsdo->privOps;
-    if (glxsdo == NULL) {
-        J2dRlsTraceLn(J2D_TRACE_ERROR,
-                      "OGLSD_GetNativeConfigInfo: glx ops are null");
-        return 0L;
-    }
-
-    if (glxsdo->configData == NULL) {
-        J2dRlsTraceLn(J2D_TRACE_ERROR,
-                      "OGLSD_GetNativeConfigInfo: config data is null");
-        return 0L;
-    }
-
-    return ptr_to_jlong(glxsdo->configData->glxInfo);
 }
 
 /**

--- a/src/jdk/src/windows/classes/sun/java2d/opengl/WGLSurfaceData.java
+++ b/src/jdk/src/windows/classes/sun/java2d/opengl/WGLSurfaceData.java
@@ -41,8 +41,8 @@ public abstract class WGLSurfaceData extends OGLSurfaceData {
     protected WComponentPeer peer;
     private WGLGraphicsConfig graphicsConfig;
 
-    private native void initOps(long pConfigInfo, WComponentPeer peer,
-                                long hwnd);
+    private native void initOps(OGLGraphicsConfig gc, long pConfigInfo,
+                                WComponentPeer peer, long hwnd);
     protected native boolean initPbuffer(long pData, long pConfigInfo,
                                          boolean isOpaque,
                                          int width, int height);
@@ -57,7 +57,7 @@ public abstract class WGLSurfaceData extends OGLSurfaceData {
         long pConfigInfo = gc.getNativeConfigInfo();
         long hwnd = peer != null ? peer.getHWnd() : 0L;
 
-        initOps(pConfigInfo, peer, hwnd);
+        initOps(gc, pConfigInfo, peer, hwnd);
     }
 
     public GraphicsConfiguration getDeviceConfiguration() {

--- a/src/jdk/src/windows/native/sun/java2d/opengl/WGLSurfaceData.c
+++ b/src/jdk/src/windows/native/sun/java2d/opengl/WGLSurfaceData.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,12 +58,29 @@ extern void
 
 JNIEXPORT void JNICALL
 Java_sun_java2d_opengl_WGLSurfaceData_initOps(JNIEnv *env, jobject wglsd,
-                                              jlong pConfigInfo,
+                                              jobject gc, jlong pConfigInfo,
                                               jobject peer, jlong hwnd)
 {
-    OGLSDOps *oglsdo = (OGLSDOps *)SurfaceData_InitOps(env, wglsd,
+    OGLSDOps *oglsdo;
+    WGLSDOps *wglsdo;
+
+    gc = (*env)->NewGlobalRef(env, gc);
+    if (gc == NULL) {
+        JNU_ThrowOutOfMemoryError(env, "Initialization of SurfaceData failed.");
+        return;
+    }
+
+    oglsdo = (OGLSDOps *)SurfaceData_InitOps(env, wglsd,
                                                        sizeof(OGLSDOps));
-    WGLSDOps *wglsdo = (WGLSDOps *)malloc(sizeof(WGLSDOps));
+    if (oglsdo == NULL) {
+        (*env)->DeleteGlobalRef(env, gc);
+        JNU_ThrowOutOfMemoryError(env, "Initialization of SurfaceData failed.");
+        return;
+    }
+    // later the graphicsConfig will be used for deallocation of oglsdo
+    oglsdo->graphicsConfig = gc;
+
+    wglsdo = (WGLSDOps *)malloc(sizeof(WGLSDOps));
 
     J2dTraceLn(J2D_TRACE_INFO, "WGLSurfaceData_initOps");
 
@@ -157,33 +174,6 @@ WGLSD_MakeCurrentToScratch(JNIEnv *env, OGLContext *oglc)
     }
 
     return JNI_TRUE;
-}
-
-/**
- * Returns a pointer (as a jlong) to the native WGLGraphicsConfigInfo
- * associated with the given OGLSDOps.  This method can be called from
- * shared code to retrieve the native GraphicsConfig data in a platform-
- * independent manner.
- */
-jlong
-OGLSD_GetNativeConfigInfo(OGLSDOps *oglsdo)
-{
-    WGLSDOps *wglsdo;
-
-    if (oglsdo == NULL) {
-        J2dRlsTraceLn(J2D_TRACE_ERROR,
-                      "OGLSD_GetNativeConfigInfo: ops are null");
-        return 0L;
-    }
-
-    wglsdo = (WGLSDOps *)oglsdo->privOps;
-    if (wglsdo == NULL) {
-        J2dRlsTraceLn(J2D_TRACE_ERROR,
-                      "OGLSD_GetNativeConfigInfo: wgl ops are null");
-        return 0L;
-    }
-
-    return ptr_to_jlong(wglsdo->configInfo);
 }
 
 /**

--- a/src/jdk/test/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
+++ b/src/jdk/test/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug     6173675
+ * @bug     6173675 8231209
  * @summary Basic test of ThreadMXBean.getThreadAllocatedBytes
  * @author  Paul Hohensee
  */
@@ -33,9 +33,8 @@ import java.lang.management.*;
 public class ThreadAllocatedMemory {
     private static com.sun.management.ThreadMXBean mbean =
         (com.sun.management.ThreadMXBean)ManagementFactory.getThreadMXBean();
-    private static boolean testFailed = false;
-    private static boolean done = false;
-    private static boolean done1 = false;
+    private static volatile boolean done = false;
+    private static volatile boolean done1 = false;
     private static Object obj = new Object();
     private static final int NUM_THREADS = 10;
     private static Thread[] threads = new Thread[NUM_THREADS];
@@ -44,6 +43,22 @@ public class ThreadAllocatedMemory {
     public static void main(String[] argv)
         throws Exception {
 
+        testSupportEnableDisable();
+
+        // Test current thread two ways
+        testGetCurrentThreadAllocatedBytes();
+        testCurrentThreadGetThreadAllocatedBytes();
+
+        // Test a single thread that is not this one
+        testGetThreadAllocatedBytes();
+
+        // Test many threads that are not this one
+        testGetThreadsAllocatedBytes();
+
+        System.out.println("Test passed");
+    }
+
+    private static void testSupportEnableDisable() {
         if (!mbean.isThreadAllocatedMemorySupported()) {
             return;
         }
@@ -58,10 +73,7 @@ public class ThreadAllocatedMemory {
                 "ThreadAllocatedMemory is expected to be disabled");
         }
 
-        Thread curThread = Thread.currentThread();
-        long id = curThread.getId();
-
-        long s = mbean.getThreadAllocatedBytes(id);
+        long s = mbean.getCurrentThreadAllocatedBytes();
         if (s != -1) {
             throw new RuntimeException(
                 "Invalid ThreadAllocatedBytes returned = " +
@@ -77,63 +89,106 @@ public class ThreadAllocatedMemory {
             throw new RuntimeException(
                 "ThreadAllocatedMemory is expected to be enabled");
         }
+    }
 
-        long size = mbean.getThreadAllocatedBytes(id);
-        // implementation could have started measurement when
-        // measurement was enabled, in which case size can be 0
-        if (size < 0) {
-            throw new RuntimeException(
-                "Invalid allocated bytes returned = " + size);
-        }
+    private static void testGetCurrentThreadAllocatedBytes() {
+        long size = mbean.getCurrentThreadAllocatedBytes();
+        ensureValidSize(size);
 
+        // do some more allocation
         doit();
 
-        // Expected to be size1 >= size
-        long size1 = mbean.getThreadAllocatedBytes(id);
-        if (size1 < size) {
-            throw new RuntimeException("Allocated bytes " + size1 +
-                " expected >= " + size);
-        }
-        System.out.println(curThread.getName() +
-            " Current thread allocated bytes = " + size +
-            " allocated bytes = " + size1);
+        checkResult(Thread.currentThread(), size,
+                    mbean.getCurrentThreadAllocatedBytes());
+    }
 
+    private static void testCurrentThreadGetThreadAllocatedBytes() {
+        Thread curThread = Thread.currentThread();
+        long id = curThread.getId();
 
-        // start threads, wait for them to block
-        for (int i = 0; i < NUM_THREADS; i++) {
-            threads[i] = new MyThread("MyThread-" + i);
-            threads[i].start();
-        }
+        long size = mbean.getThreadAllocatedBytes(id);
+        ensureValidSize(size);
 
-        // threads block after doing some allocation
-        waitUntilThreadBlocked();
+        // do some more allocation
+        doit();
 
-        for (int i = 0; i < NUM_THREADS; i++) {
-            sizes[i] = mbean.getThreadAllocatedBytes(threads[i].getId());
-        }
+        checkResult(curThread, size, mbean.getThreadAllocatedBytes(id));
+    }
 
-        // let threads go and do some more allocation
+    private static void testGetThreadAllocatedBytes()
+        throws Exception {
+
+        // start a thread
+        done = false; done1 = false;
+        Thread curThread = new MyThread("MyThread");
+        curThread.start();
+        long id = curThread.getId();
+
+        // wait for thread to block after doing some allocation
+        waitUntilThreadBlocked(curThread);
+
+        long size = mbean.getThreadAllocatedBytes(id);
+        ensureValidSize(size);
+
+        // let thread go to do some more allocation
         synchronized (obj) {
             done = true;
             obj.notifyAll();
         }
 
-        // wait for threads to get going again.  we don't care if we
+        // wait for thread to get going again. we don't care if we
+        // catch it in mid-execution or if it hasn't
+        // restarted after we're done sleeping.
+        goSleep(400);
+
+        checkResult(curThread, size, mbean.getThreadAllocatedBytes(id));
+
+        // let thread exit
+        synchronized (obj) {
+            done1 = true;
+            obj.notifyAll();
+        }
+
+        try {
+            curThread.join();
+        } catch (InterruptedException e) {
+            System.out.println("Unexpected exception is thrown.");
+            e.printStackTrace(System.out);
+        }
+    }
+
+    private static void testGetThreadsAllocatedBytes()
+        throws Exception {
+
+        // start threads
+        done = false; done1 = false;
+        for (int i = 0; i < NUM_THREADS; i++) {
+            threads[i] = new MyThread("MyThread-" + i);
+            threads[i].start();
+        }
+
+        // wait for threads to block after doing some allocation
+        waitUntilThreadsBlocked();
+
+        for (int i = 0; i < NUM_THREADS; i++) {
+            sizes[i] = mbean.getThreadAllocatedBytes(threads[i].getId());
+            ensureValidSize(sizes[i]);
+        }
+
+        // let threads go to do some more allocation
+        synchronized (obj) {
+            done = true;
+            obj.notifyAll();
+        }
+
+        // wait for threads to get going again. we don't care if we
         // catch them in mid-execution or if some of them haven't
         // restarted after we're done sleeping.
         goSleep(400);
 
         for (int i = 0; i < NUM_THREADS; i++) {
-            long newSize = mbean.getThreadAllocatedBytes(threads[i].getId());
-            if (sizes[i] > newSize) {
-                throw new RuntimeException("TEST FAILED: " +
-                    threads[i].getName() +
-                    " previous allocated bytes = " + sizes[i] +
-                    " > current allocated bytes = " + newSize);
-            }
-            System.out.println(threads[i].getName() +
-                " Previous allocated bytes = " + sizes[i] +
-                " Current allocated bytes = " + newSize);
+            checkResult(threads[i], sizes[i],
+                        mbean.getThreadAllocatedBytes(threads[i].getId()));
         }
 
         // let threads exit
@@ -148,17 +203,30 @@ public class ThreadAllocatedMemory {
             } catch (InterruptedException e) {
                 System.out.println("Unexpected exception is thrown.");
                 e.printStackTrace(System.out);
-                testFailed = true;
                 break;
             }
         }
-        if (testFailed) {
-            throw new RuntimeException("TEST FAILED");
-        }
-
-        System.out.println("Test passed");
     }
 
+    private static void ensureValidSize(long size) {
+        // implementation could have started measurement when
+        // measurement was enabled, in which case size can be 0
+        if (size < 0) {
+            throw new RuntimeException(
+                "Invalid allocated bytes returned = " + size);
+        }
+    }
+
+    private static void checkResult(Thread curThread,
+                                    long prev_size, long curr_size) {
+        if (curr_size < prev_size) {
+            throw new RuntimeException("Allocated bytes " + curr_size +
+                                       " expected >= " + prev_size);
+        }
+        System.out.println(curThread.getName() +
+                           " Previous allocated bytes = " + prev_size +
+                           " Current allocated bytes = " + curr_size);
+    }
 
     private static void goSleep(long ms) throws Exception {
         try {
@@ -169,7 +237,18 @@ public class ThreadAllocatedMemory {
         }
     }
 
-    private static void waitUntilThreadBlocked()
+    private static void waitUntilThreadBlocked(Thread thread)
+        throws Exception {
+        while (true) {
+            goSleep(100);
+            ThreadInfo info = mbean.getThreadInfo(thread.getId());
+            if (info.getThreadState() == Thread.State.WAITING) {
+                break;
+            }
+        }
+    }
+
+    private static void waitUntilThreadsBlocked()
         throws Exception {
         int count = 0;
         while (count != NUM_THREADS) {
@@ -210,7 +289,6 @@ public class ThreadAllocatedMemory {
                     } catch (InterruptedException e) {
                         System.out.println("Unexpected exception is thrown.");
                         e.printStackTrace(System.out);
-                        testFailed = true;
                         break;
                     }
                 }
@@ -225,7 +303,7 @@ public class ThreadAllocatedMemory {
                 " ThreadAllocatedBytes  = " + size2);
 
             if (size1 > size2) {
-                throw new RuntimeException("TEST FAILED: " + getName() +
+                throw new RuntimeException(getName() +
                     " ThreadAllocatedBytes = " + size1 +
                     " > ThreadAllocatedBytes = " + size2);
             }
@@ -237,7 +315,6 @@ public class ThreadAllocatedMemory {
                     } catch (InterruptedException e) {
                         System.out.println("Unexpected exception is thrown.");
                         e.printStackTrace(System.out);
-                        testFailed = true;
                         break;
                     }
                 }


### PR DESCRIPTION
### Description
Backport from OpenJDK.
Fixes a bug on macosx when switching between user accounts or opening/closing the lid

### Related issues
JBS Issue: https://bugs.openjdk.java.net/browse/JDK-8146238

### Motivation and context
Reported as a problem in [corretto-11 #46](https://github.com/corretto/corretto-11/issues/46)


### How has this been tested?
Tier1 and Tier2 testing
