### PR TITLE
[backport] 8062808:Turn on the -Wreturn-type warning

### DIFF
--- a/src/hotspot/src/cpu/x86/vm/x86_32.ad
+++ b/src/hotspot/src/cpu/x86/vm/x86_32.ad
@@ -1250,6 +1250,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
 
 
   Unimplemented();
+  return 0; // Mute compiler
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
+++ b/src/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
@@ -540,7 +540,7 @@ JVM_handle_linux_signal(int sig,
   err.report_and_die();
 
   ShouldNotReachHere();
-  return false; // Mute compiler
+  return true; // Mute compiler
 }
 
 void os::Linux::init_thread_fpu_state(void) {

--- a/src/hotspot/src/share/vm/classfile/defaultMethods.cpp
+++ b/src/hotspot/src/share/vm/classfile/defaultMethods.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -506,7 +506,7 @@ Symbol* MethodFamily::generate_method_message(Symbol *klass_name, Method* method
   ss.write((const char*)name->bytes(), name->utf8_length());
   ss.write((const char*)signature->bytes(), signature->utf8_length());
   ss.print(" is abstract");
-  return SymbolTable::new_symbol(ss.base(), (int)ss.size(), CHECK_NULL);
+  return SymbolTable::new_symbol(ss.base(), (int)ss.size(), THREAD);
 }
 
 Symbol* MethodFamily::generate_conflicts_message(GrowableArray<Method*>* methods, TRAPS) const {
@@ -521,7 +521,7 @@ Symbol* MethodFamily::generate_conflicts_message(GrowableArray<Method*>* methods
     ss.print(".");
     ss.write((const char*)name->bytes(), name->utf8_length());
   }
-  return SymbolTable::new_symbol(ss.base(), (int)ss.size(), CHECK_NULL);
+  return SymbolTable::new_symbol(ss.base(), (int)ss.size(), THREAD);
 }
 
 

--- a/src/hotspot/src/share/vm/classfile/symbolTable.cpp
+++ b/src/hotspot/src/share/vm/classfile/symbolTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -249,7 +249,7 @@ Symbol* SymbolTable::lookup(const char* name, int len, TRAPS) {
   MutexLocker ml(SymbolTable_lock, THREAD);
 
   // Otherwise, add to symbol to table
-  return the_table()->basic_add(index, (u1*)name, len, hashValue, true, CHECK_NULL);
+  return the_table()->basic_add(index, (u1*)name, len, hashValue, true, THREAD);
 }
 
 Symbol* SymbolTable::lookup(const Symbol* sym, int begin, int end, TRAPS) {
@@ -288,7 +288,7 @@ Symbol* SymbolTable::lookup(const Symbol* sym, int begin, int end, TRAPS) {
   // Grab SymbolTable_lock first.
   MutexLocker ml(SymbolTable_lock, THREAD);
 
-  return the_table()->basic_add(index, (u1*)buffer, len, hashValue, true, CHECK_NULL);
+  return the_table()->basic_add(index, (u1*)buffer, len, hashValue, true, THREAD);
 }
 
 Symbol* SymbolTable::lookup_only(const char* name, int len,

--- a/src/hotspot/src/share/vm/classfile/systemDictionary.cpp
+++ b/src/hotspot/src/share/vm/classfile/systemDictionary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -229,15 +229,15 @@ Klass* SystemDictionary::resolve_or_null(Symbol* class_name, Handle class_loader
                  class_name->as_C_string(),
                  class_loader.is_null() ? "null" : class_loader->klass()->name()->as_C_string()));
   if (FieldType::is_array(class_name)) {
-    return resolve_array_class_or_null(class_name, class_loader, protection_domain, CHECK_NULL);
+    return resolve_array_class_or_null(class_name, class_loader, protection_domain, THREAD);
   } else if (FieldType::is_obj(class_name)) {
     ResourceMark rm(THREAD);
     // Ignore wrapping L and ;.
     TempNewSymbol name = SymbolTable::new_symbol(class_name->as_C_string() + 1,
                                    class_name->utf8_length() - 2, CHECK_NULL);
-    return resolve_instance_class_or_null(name, class_loader, protection_domain, CHECK_NULL);
+    return resolve_instance_class_or_null(name, class_loader, protection_domain, THREAD);
   } else {
-    return resolve_instance_class_or_null(class_name, class_loader, protection_domain, CHECK_NULL);
+    return resolve_instance_class_or_null(class_name, class_loader, protection_domain, THREAD);
   }
 }
 

--- a/src/hotspot/src/share/vm/memory/heapInspection.hpp
+++ b/src/hotspot/src/share/vm/memory/heapInspection.hpp
@@ -367,7 +367,7 @@ class HeapInspection : public StackObj {
       _csv_format(csv_format), _print_help(print_help),
       _print_class_stats(print_class_stats), _columns(columns) {}
   void heap_inspection(outputStream* st) NOT_SERVICES_RETURN;
-  size_t populate_table(KlassInfoTable* cit, BoolObjectClosure* filter = NULL) NOT_SERVICES_RETURN_(0);
+  size_t populate_table(KlassInfoTable* cit, BoolObjectClosure* filter = NULL) NOT_SERVICES_RETURN;
   static void find_instances_at_safepoint(Klass* k, GrowableArray<oop>* result) NOT_SERVICES_RETURN;
  private:
   void iterate_over_heap(KlassInfoTable* cit, BoolObjectClosure* filter = NULL);

--- a/src/hotspot/src/share/vm/memory/metaspaceShared.hpp
+++ b/src/hotspot/src/share/vm/memory/metaspaceShared.hpp
@@ -93,7 +93,7 @@ class MetaspaceShared : AllStatic {
   static void preload_and_dump(TRAPS) NOT_CDS_RETURN;
   static int preload_and_dump(const char * class_list_path,
                               GrowableArray<Klass*>* class_promote_order,
-                              TRAPS) NOT_CDS_RETURN_(0);
+                              TRAPS) NOT_CDS_RETURN;
 
   static ReservedSpace* shared_rs() {
     CDS_ONLY(return _shared_rs);

--- a/src/hotspot/src/share/vm/oops/constantPool.hpp
+++ b/src/hotspot/src/share/vm/oops/constantPool.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -353,7 +353,7 @@ class ConstantPool : public Metadata {
 
   Klass* klass_at(int which, TRAPS) {
     constantPoolHandle h_this(THREAD, this);
-    return klass_at_impl(h_this, which, CHECK_NULL);
+    return klass_at_impl(h_this, which, THREAD);
   }
 
   Symbol* klass_name_at(int which);  // Returns the name, w/o resolving.

--- a/src/hotspot/src/share/vm/prims/jni.cpp
+++ b/src/hotspot/src/share/vm/prims/jni.cpp
@@ -5101,6 +5101,7 @@ void TestVirtualSpaceNode_test();
 void TestNewSize_test();
 void TestKlass_test();
 void Test_linked_list();
+void TestSimpleHashtable_test();
 void TestChunkedList_test();
 #if INCLUDE_ALL_GCS
 void TestOldFreeSpaceCalculation_test();
@@ -5133,6 +5134,7 @@ void execute_internal_vm_tests() {
     run_unit_test(test_snprintf());
     run_unit_test(TestNewSize_test());
     run_unit_test(TestKlass_test());
+    run_unit_test(TestSimpleHashtable_test());
     run_unit_test(Test_linked_list());
     run_unit_test(TestChunkedList_test());
     run_unit_test(ObjectMonitor::sanity_checks());

--- a/src/hotspot/src/share/vm/prims/jvm.cpp
+++ b/src/hotspot/src/share/vm/prims/jvm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -908,7 +908,7 @@ JVM_END
 JVM_ENTRY(jboolean, JVM_KnownToNotExist(JNIEnv *env, jobject loader, const char *classname))
   JVMWrapper("JVM_KnownToNotExist");
 #if INCLUDE_CDS
-  return ClassLoaderExt::known_to_not_exist(env, loader, classname, CHECK_(false));
+  return ClassLoaderExt::known_to_not_exist(env, loader, classname, THREAD);
 #else
   return false;
 #endif
@@ -918,7 +918,7 @@ JVM_END
 JVM_ENTRY(jobjectArray, JVM_GetResourceLookupCacheURLs(JNIEnv *env, jobject loader))
   JVMWrapper("JVM_GetResourceLookupCacheURLs");
 #if INCLUDE_CDS
-  return ClassLoaderExt::get_lookup_cache_urls(env, loader, CHECK_NULL);
+  return ClassLoaderExt::get_lookup_cache_urls(env, loader, THREAD);
 #else
   return NULL;
 #endif
@@ -928,7 +928,7 @@ JVM_END
 JVM_ENTRY(jintArray, JVM_GetResourceLookupCache(JNIEnv *env, jobject loader, const char *resource_name))
   JVMWrapper("JVM_GetResourceLookupCache");
 #if INCLUDE_CDS
-  return ClassLoaderExt::get_lookup_cache(env, loader, resource_name, CHECK_NULL);
+  return ClassLoaderExt::get_lookup_cache(env, loader, resource_name, THREAD);
 #else
   return NULL;
 #endif
@@ -4343,7 +4343,7 @@ JVM_ENTRY(jlong,JVM_DTraceActivate(
     JVM_DTraceProvider* providers))
   JVMWrapper("JVM_DTraceActivate");
   return DTraceJSDT::activate(
-    version, module_name, providers_count, providers, CHECK_0);
+    version, module_name, providers_count, providers, THREAD);
 JVM_END
 
 JVM_ENTRY(jboolean,JVM_DTraceIsProbeEnabled(JNIEnv* env, jmethodID method))

--- a/src/hotspot/src/share/vm/runtime/perfData.hpp
+++ b/src/hotspot/src/share/vm/runtime/perfData.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -773,7 +773,7 @@ class PerfDataManager : AllStatic {
     static PerfStringVariable* create_string_variable(CounterNS ns,
                                                       const char* name,
                                                       const char *s, TRAPS) {
-      return create_string_variable(ns, name, 0, s, CHECK_NULL);
+      return create_string_variable(ns, name, 0, s, THREAD);
     };
 
     static PerfLongVariable* create_long_variable(CounterNS ns,
@@ -784,7 +784,7 @@ class PerfDataManager : AllStatic {
     static PerfLongVariable* create_long_variable(CounterNS ns,
                                                   const char* name,
                                                   PerfData::Units u, TRAPS) {
-      return create_long_variable(ns, name, u, (jlong)0, CHECK_NULL);
+      return create_long_variable(ns, name, u, (jlong)0, THREAD);
     };
 
     static PerfLongVariable* create_long_variable(CounterNS, const char* name,
@@ -805,7 +805,7 @@ class PerfDataManager : AllStatic {
 
     static PerfLongCounter* create_long_counter(CounterNS ns, const char* name,
                                                 PerfData::Units u, TRAPS) {
-      return create_long_counter(ns, name, u, (jlong)0, CHECK_NULL);
+      return create_long_counter(ns, name, u, (jlong)0, THREAD);
     };
 
     static PerfLongCounter* create_long_counter(CounterNS ns, const char* name,
@@ -823,49 +823,49 @@ class PerfDataManager : AllStatic {
 
     static PerfConstant* create_constant(CounterNS ns, const char* name,
                                          PerfData::Units u, jlong val, TRAPS) {
-      return create_long_constant(ns, name, u, val, CHECK_NULL);
+      return create_long_constant(ns, name, u, val, THREAD);
     }
 
     static PerfVariable* create_variable(CounterNS ns, const char* name,
                                          PerfData::Units u, jlong ival, TRAPS) {
-      return create_long_variable(ns, name, u, ival, CHECK_NULL);
+      return create_long_variable(ns, name, u, ival, THREAD);
     }
 
     static PerfVariable* create_variable(CounterNS ns, const char* name,
                                          PerfData::Units u, TRAPS) {
-      return create_long_variable(ns, name, u, (jlong)0, CHECK_NULL);
+      return create_long_variable(ns, name, u, (jlong)0, THREAD);
     }
 
     static PerfVariable* create_variable(CounterNS ns, const char* name,
                                          PerfData::Units u, jlong* sp, TRAPS) {
-      return create_long_variable(ns, name, u, sp, CHECK_NULL);
+      return create_long_variable(ns, name, u, sp, THREAD);
     }
 
     static PerfVariable* create_variable(CounterNS ns, const char* name,
                                          PerfData::Units u,
                                          PerfSampleHelper* sh, TRAPS) {
-      return create_long_variable(ns, name, u, sh, CHECK_NULL);
+      return create_long_variable(ns, name, u, sh, THREAD);
     }
 
     static PerfCounter* create_counter(CounterNS ns, const char* name,
                                        PerfData::Units u, jlong ival, TRAPS) {
-      return create_long_counter(ns, name, u, ival, CHECK_NULL);
+      return create_long_counter(ns, name, u, ival, THREAD);
     }
 
     static PerfCounter* create_counter(CounterNS ns, const char* name,
                                        PerfData::Units u, TRAPS) {
-      return create_long_counter(ns, name, u, (jlong)0, CHECK_NULL);
+      return create_long_counter(ns, name, u, (jlong)0, THREAD);
     }
 
     static PerfCounter* create_counter(CounterNS ns, const char* name,
                                        PerfData::Units u, jlong* sp, TRAPS) {
-      return create_long_counter(ns, name, u, sp, CHECK_NULL);
+      return create_long_counter(ns, name, u, sp, THREAD);
     }
 
     static PerfCounter* create_counter(CounterNS ns, const char* name,
                                        PerfData::Units u,
                                        PerfSampleHelper* sh, TRAPS) {
-      return create_long_counter(ns, name, u, sh, CHECK_NULL);
+      return create_long_counter(ns, name, u, sh, THREAD);
     }
 
     static void destroy();

--- a/src/hotspot/src/share/vm/runtime/reflection.cpp
+++ b/src/hotspot/src/share/vm/runtime/reflection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1093,7 +1093,7 @@ oop Reflection::invoke(instanceKlassHandle klass, methodHandle reflected_method,
   } else {
     if (rtype == T_BOOLEAN || rtype == T_BYTE || rtype == T_CHAR || rtype == T_SHORT)
       narrow((jvalue*) result.get_value_addr(), rtype, CHECK_NULL);
-    return box((jvalue*) result.get_value_addr(), rtype, CHECK_NULL);
+    return box((jvalue*) result.get_value_addr(), rtype, THREAD);
   }
 }
 

--- a/src/hotspot/src/share/vm/runtime/sharedRuntime.cpp
+++ b/src/hotspot/src/share/vm/runtime/sharedRuntime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1045,7 +1045,7 @@ Handle SharedRuntime::find_callee_info(JavaThread* thread, Bytecodes::Code& bc, 
   // last java frame on stack (which includes native call frames)
   vframeStream vfst(thread, true);  // Do not skip and javaCalls
 
-  return find_callee_info_helper(thread, vfst, bc, callinfo, CHECK_(Handle()));
+  return find_callee_info_helper(thread, vfst, bc, callinfo, THREAD);
 }
 
 

--- a/src/hotspot/src/share/vm/services/memTracker.hpp
+++ b/src/hotspot/src/share/vm/services/memTracker.hpp
@@ -64,7 +64,7 @@ class MemTracker : AllStatic {
     const NativeCallStack& stack, MEMFLAGS flag = mtNone) { }
   static inline void record_virtual_memory_commit(void* addr, size_t size, const NativeCallStack& stack) { }
   static inline Tracker get_virtual_memory_uncommit_tracker() { return Tracker(); }
-  static inline Tracker get_virtual_memory_release_tracker() { }
+  static inline Tracker get_virtual_memory_release_tracker() { return Tracker(); }
   static inline void record_virtual_memory_type(void* addr, MEMFLAGS flag) { }
   static inline void record_thread_stack(void* addr, size_t size) { }
   static inline void release_thread_stack(void* addr, size_t size) { }

--- a/src/hotspot/src/share/vm/utilities/hashFns.hpp
+++ b/src/hotspot/src/share/vm/utilities/hashFns.hpp
@@ -33,7 +33,7 @@ template<typename K> struct HashFns {
 
   static unsigned primitive_hash(const K& k) {
     unsigned hash = (unsigned)((uintptr_t)k);
-    return hash ^ (hash > 3); // just in case we're dealing with aligned ptrs
+    return hash ^ (hash >> 3); // just in case we're dealing with aligned ptrs
   }
 
   static bool primitive_equals(const K& k0, const K& k1) {

--- a/src/hotspot/src/share/vm/utilities/simpleOpenHashtable.cpp
+++ b/src/hotspot/src/share/vm/utilities/simpleOpenHashtable.cpp
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/simpleOpenHashtable.hpp"
+
+#ifndef PRODUCT
+
+/////////////// Unit tests ///////////////
+class TestSimpleHashtable : public AllStatic {
+    typedef intx K;
+    typedef int V;
+
+    static unsigned identity_hash(const K& k) {
+        return (unsigned)(uintptr_t)k;
+    }
+
+    static unsigned bad_hash(const K& k) {
+        return 1;
+    }
+
+    class EqualityTestIter {
+    public:
+        bool do_entry(K const& k, V const& v) {
+            assert((uintptr_t)k == (uintptr_t)v, "");
+            return true; // continue iteration
+        }
+    };
+
+  template<
+  unsigned (*HASH)  (K const&)           = HashFns<K>::primitive_hash,
+  bool     (*EQUALS)(K const&, K const&) = HashFns<K>::primitive_equals
+  >
+  class Runner : public AllStatic {
+    static K as_K(intx val) { return val; }
+
+   public:
+    static void test_small() {
+      EqualityTestIter et;
+      SimpleOpenHashtable<K, V, HASH, EQUALS> rh;
+
+      assert(!rh.contains(as_K(0x1)), "");
+
+      assert(!rh.put(as_K(0x1), 0x1), "put 1 failed! duplication detected.");
+      assert(rh.contains(as_K(0x1)), "");
+
+      assert(rh.put(as_K(0x1), 0x1), "put 1 failed! should update");
+
+      assert(!rh.put(as_K(0x2), 0x2), "");
+      assert(!rh.put(as_K(0x3), 0x3), "");
+      assert(!rh.put(as_K(0x4), 0x4), "");
+      assert(!rh.put(as_K(0x5), 0x5), "");
+
+      assert(!rh.remove(as_K(0x0)), "Failed to remove 0");
+      rh.iterate(&et);
+
+      assert(rh.remove(as_K(0x1)), "");
+      rh.iterate(&et);
+    }
+
+    // We use keys with the low bits cleared since the default hash will do some shifting
+    static void test_small_shifted() {
+      EqualityTestIter et;
+      SimpleOpenHashtable<K, V, HASH, EQUALS> rh;
+
+      assert(!rh.contains(as_K(0x10)), "");
+
+      assert(!rh.put(as_K(0x10), 0x10), "put 1 failed! duplication detectected");
+      assert(rh.contains(as_K(0x10)), "");
+
+      assert(rh.put(as_K(0x10), 0x10), "put 1 failed! should update");
+
+      assert(!rh.put(as_K(0x20), 0x20), "");
+      assert(!rh.put(as_K(0x30), 0x30), "");
+      assert(!rh.put(as_K(0x40), 0x40), "");
+      assert(!rh.put(as_K(0x50), 0x50), "");
+
+      assert(!rh.remove(as_K(0x00)), "");
+
+      assert(rh.remove(as_K(0x10)), "");
+
+      rh.iterate(&et);
+    }
+
+    static void test(unsigned num_elements) {
+      EqualityTestIter et;
+      SimpleOpenHashtable<K, V, HASH, EQUALS> rh;
+
+      for (uintptr_t i = 0; i < num_elements; ++i) {
+        assert(!rh.put(as_K(i), i), "");
+      }
+
+      rh.iterate(&et);
+
+      for (uintptr_t i = num_elements; i > 0; --i) {
+        uintptr_t index = i - 1;
+        assert(rh.remove(as_K(index)), "");
+      }
+      rh.iterate(&et);
+      for (uintptr_t i = num_elements; i > 0; --i) {
+        uintptr_t index = i - 1;
+        assert(!rh.remove(as_K(index)), "");
+      }
+      rh.iterate(&et);
+    }
+  };
+
+  template<typename K>
+  static unsigned colliding_hash(const K& k) {
+    unsigned hash = (unsigned)((uintptr_t)k);
+    return hash >> 3; // Force collisions at a stride of 8.
+  }
+
+public:
+    static void run_tests() {
+        {
+            typedef SimpleOpenHashtable<intx, intx, bad_hash> IntMap;
+            IntMap map(1000, DEFAULT_LOAD_FACTOR);
+
+            assert(!map.put(2, 2), "");
+            assert(!map.put(3, 2), "");
+            assert(!map.put(4, 3), "");
+            assert(!map.put(5, 3), "");
+            assert(map.put(2, 1), "Failed to update");
+            assert(!map.put(6, 4), "");
+            assert(map.put(6, 4), "");
+
+            assert(map.remove(2), "Failed to remove 2");
+            assert(map.contains(3), "Failed to get 3");
+            assert(map.contains(4), "failed to get 4");
+            assert(map.remove(3), "Failed to remove 3");
+            assert(map.contains(4), "Failed to get 4");
+            assert(map.remove(4), "Failed to remove 4");
+            assert(map.contains(5), "Failed to get 5");
+
+            assert(map.remove(5), "Failed to remove 5");
+            assert(map.contains(6), "Failed to get 6");
+            assert(map.remove(6), "Failed to remove 6");
+            assert(map.entry_count() == 0, "Not empty");
+        }
+
+        {
+            typedef SimpleOpenHashtable<intx, intx, colliding_hash> IntMap;
+
+            IntMap map(1024, DEFAULT_LOAD_FACTOR);
+
+            assert(!map.put(0, 1), "Failed to insert");
+            assert(!map.put(8, 8), "Failed to insert");
+
+            assert(!map.put(8180, 8180), "Failed to insert");
+            assert(!map.put(8184, 8184), "Failed to insert");
+
+            assert(!map.put(8181, 8181), "Failed to insert");
+            assert(!map.put(8182, 8182), "Failed to insert");
+            assert(!map.put(8183, 8183), "Failed to insert");
+
+            assert(7 == map.entry_count(), "Size is 7");
+
+            assert(map.remove(0), "Failed to remove 0");
+
+            assert(map.get(8) == 8, "Failed to get");
+            assert(map.get(8180) == 8180, "Failed to get");
+            assert(map.get(8181) == 8181, "Failed to get");
+            assert(map.get(8182) == 8182, "Failed to get");
+            assert(map.get(8183) == 8183, "Failed to get");
+            assert(map.get(8184) == 8184, "Failed to get");
+
+            assert(map.remove(8180), "Failed to remove 8180");
+            assert(map.remove(8181), "Failed to remove 8181");
+
+            assert(map.get(8) == 8, "Failed to get");
+            assert(map.get(8182) == 8182, "Failed to get");
+            assert(map.get(8183) == 8183, "Failed to get");
+            assert(map.get(8184) == 8184, "Failed to get");
+
+            assert(map.remove(8184), "Failed to remove 8184");
+
+            assert(map.get(8) == 8, "Failed to get");
+            assert(map.get(8182) == 8182, "Failed to get");
+            assert(map.get(8183) == 8183, "Failed to get");
+        }
+
+        {
+            Runner<>::test_small();
+            Runner<>::test_small_shifted();
+            Runner<>::test(16);
+            Runner<>::test(128);
+            Runner<>::test(256);
+            Runner<>::test(512);
+        }
+
+        {
+            Runner<identity_hash>::test_small();
+            Runner<identity_hash>::test_small_shifted();
+            Runner<identity_hash>::test(16);
+            Runner<identity_hash>::test(128);
+            Runner<identity_hash>::test(256);
+            Runner<identity_hash>::test(512);
+        }
+
+        {
+            Runner<bad_hash>::test_small();
+            Runner<bad_hash>::test_small_shifted();
+            Runner<bad_hash>::test(16);
+            Runner<bad_hash>::test(128);
+            Runner<bad_hash>::test(256);
+            Runner<bad_hash>::test(512);
+        }
+    }
+};
+
+void TestSimpleHashtable_test() {
+  TestSimpleHashtable::run_tests();
+}
+
+#endif // not PRODUCT


### PR DESCRIPTION
Corretto-8 has enabled -Wreturn-warning. This patch allows
slowdebug build.

Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
build corretto-8 supports slowdebug build

### Related issues
JDK-1717

### Motivation and context


### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
