### PR TITLE
Backport of 8139178: Wrong fontMetrics when printing in Landscape (OpenJDK)

### DIFF
--- a/src/hotspot/src/share/vm/prims/jni.cpp
+++ b/src/hotspot/src/share/vm/prims/jni.cpp
@@ -5101,6 +5101,7 @@ void TestVirtualSpaceNode_test();
 void TestNewSize_test();
 void TestKlass_test();
 void Test_linked_list();
+void TestSimpleHashtable_test();
 void TestChunkedList_test();
 #if INCLUDE_ALL_GCS
 void TestOldFreeSpaceCalculation_test();
@@ -5133,6 +5134,7 @@ void execute_internal_vm_tests() {
     run_unit_test(test_snprintf());
     run_unit_test(TestNewSize_test());
     run_unit_test(TestKlass_test());
+    run_unit_test(TestSimpleHashtable_test());
     run_unit_test(Test_linked_list());
     run_unit_test(TestChunkedList_test());
     run_unit_test(ObjectMonitor::sanity_checks());

--- a/src/hotspot/src/share/vm/services/jmm.h
+++ b/src/hotspot/src/share/vm/services/jmm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,6 +243,9 @@ typedef struct jmmInterface_1_ {
   jobject      (JNICALL *GetMemoryPoolUsage)     (JNIEnv* env, jobject pool);
   jobject      (JNICALL *GetPeakMemoryPoolUsage) (JNIEnv* env, jobject pool);
 
+  jlong        (JNICALL *GetOneThreadAllocatedMemory)
+                                                 (JNIEnv *env,
+                                                  jlong thread_id);
   void         (JNICALL *GetThreadAllocatedMemory)
                                                  (JNIEnv *env,
                                                   jlongArray ids,

--- a/src/hotspot/src/share/vm/services/management.cpp
+++ b/src/hotspot/src/share/vm/services/management.cpp
@@ -2206,6 +2206,30 @@ jlong Management::ticks_to_ms(jlong ticks) {
 }
 #endif // INCLUDE_MANAGEMENT
 
+// Gets the amount of memory allocated on the Java heap for a single thread.
+// Returns -1 if the thread does not exist or has terminated.
+JVM_ENTRY(jlong, jmm_GetOneThreadAllocatedMemory(JNIEnv *env, jlong thread_id))
+  if (thread_id < 0) {
+    THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
+               "Invalid thread ID", -1);
+  }
+
+  if (thread_id == 0) {
+    // current thread
+    if (THREAD->is_Java_thread()) {
+      return ((JavaThread*)THREAD)->cooked_allocated_bytes();
+    }
+    return -1;
+  }
+
+  MutexLockerEx ml(Threads_lock);
+  JavaThread* java_thread = Threads::find_java_thread_from_java_tid(thread_id);
+  if (java_thread != NULL) {
+    return java_thread->cooked_allocated_bytes();
+  }
+  return -1;
+JVM_END
+
 // Gets an array containing the amount of memory allocated on the Java
 // heap for a set of threads (in bytes).  Each element of the array is
 // the amount of memory allocated for the thread ID specified in the
@@ -2332,6 +2356,7 @@ const struct jmmInterface_1_ jmm_interface = {
   jmm_GetMemoryManagers,
   jmm_GetMemoryPoolUsage,
   jmm_GetPeakMemoryPoolUsage,
+  jmm_GetOneThreadAllocatedMemory,
   jmm_GetThreadAllocatedMemory,
   jmm_GetMemoryUsage,
   jmm_GetLongAttribute,

--- a/src/hotspot/src/share/vm/utilities/hashFns.hpp
+++ b/src/hotspot/src/share/vm/utilities/hashFns.hpp
@@ -33,7 +33,7 @@ template<typename K> struct HashFns {
 
   static unsigned primitive_hash(const K& k) {
     unsigned hash = (unsigned)((uintptr_t)k);
-    return hash ^ (hash > 3); // just in case we're dealing with aligned ptrs
+    return hash ^ (hash >> 3); // just in case we're dealing with aligned ptrs
   }
 
   static bool primitive_equals(const K& k0, const K& k1) {

--- a/src/hotspot/src/share/vm/utilities/simpleOpenHashtable.cpp
+++ b/src/hotspot/src/share/vm/utilities/simpleOpenHashtable.cpp
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/simpleOpenHashtable.hpp"
+
+#ifndef PRODUCT
+
+/////////////// Unit tests ///////////////
+class TestSimpleHashtable : public AllStatic {
+    typedef intx K;
+    typedef int V;
+
+    static unsigned identity_hash(const K& k) {
+        return (unsigned)(uintptr_t)k;
+    }
+
+    static unsigned bad_hash(const K& k) {
+        return 1;
+    }
+
+    class EqualityTestIter {
+    public:
+        bool do_entry(K const& k, V const& v) {
+            assert((uintptr_t)k == (uintptr_t)v, "");
+            return true; // continue iteration
+        }
+    };
+
+  template<
+  unsigned (*HASH)  (K const&)           = HashFns<K>::primitive_hash,
+  bool     (*EQUALS)(K const&, K const&) = HashFns<K>::primitive_equals
+  >
+  class Runner : public AllStatic {
+    static K as_K(intx val) { return val; }
+
+   public:
+    static void test_small() {
+      EqualityTestIter et;
+      SimpleOpenHashtable<K, V, HASH, EQUALS> rh;
+
+      assert(!rh.contains(as_K(0x1)), "");
+
+      assert(!rh.put(as_K(0x1), 0x1), "put 1 failed! duplication detected.");
+      assert(rh.contains(as_K(0x1)), "");
+
+      assert(rh.put(as_K(0x1), 0x1), "put 1 failed! should update");
+
+      assert(!rh.put(as_K(0x2), 0x2), "");
+      assert(!rh.put(as_K(0x3), 0x3), "");
+      assert(!rh.put(as_K(0x4), 0x4), "");
+      assert(!rh.put(as_K(0x5), 0x5), "");
+
+      assert(!rh.remove(as_K(0x0)), "Failed to remove 0");
+      rh.iterate(&et);
+
+      assert(rh.remove(as_K(0x1)), "");
+      rh.iterate(&et);
+    }
+
+    // We use keys with the low bits cleared since the default hash will do some shifting
+    static void test_small_shifted() {
+      EqualityTestIter et;
+      SimpleOpenHashtable<K, V, HASH, EQUALS> rh;
+
+      assert(!rh.contains(as_K(0x10)), "");
+
+      assert(!rh.put(as_K(0x10), 0x10), "put 1 failed! duplication detectected");
+      assert(rh.contains(as_K(0x10)), "");
+
+      assert(rh.put(as_K(0x10), 0x10), "put 1 failed! should update");
+
+      assert(!rh.put(as_K(0x20), 0x20), "");
+      assert(!rh.put(as_K(0x30), 0x30), "");
+      assert(!rh.put(as_K(0x40), 0x40), "");
+      assert(!rh.put(as_K(0x50), 0x50), "");
+
+      assert(!rh.remove(as_K(0x00)), "");
+
+      assert(rh.remove(as_K(0x10)), "");
+
+      rh.iterate(&et);
+    }
+
+    static void test(unsigned num_elements) {
+      EqualityTestIter et;
+      SimpleOpenHashtable<K, V, HASH, EQUALS> rh;
+
+      for (uintptr_t i = 0; i < num_elements; ++i) {
+        assert(!rh.put(as_K(i), i), "");
+      }
+
+      rh.iterate(&et);
+
+      for (uintptr_t i = num_elements; i > 0; --i) {
+        uintptr_t index = i - 1;
+        assert(rh.remove(as_K(index)), "");
+      }
+      rh.iterate(&et);
+      for (uintptr_t i = num_elements; i > 0; --i) {
+        uintptr_t index = i - 1;
+        assert(!rh.remove(as_K(index)), "");
+      }
+      rh.iterate(&et);
+    }
+  };
+
+  template<typename K>
+  static unsigned colliding_hash(const K& k) {
+    unsigned hash = (unsigned)((uintptr_t)k);
+    return hash >> 3; // Force collisions at a stride of 8.
+  }
+
+public:
+    static void run_tests() {
+        {
+            typedef SimpleOpenHashtable<intx, intx, bad_hash> IntMap;
+            IntMap map(1000, DEFAULT_LOAD_FACTOR);
+
+            assert(!map.put(2, 2), "");
+            assert(!map.put(3, 2), "");
+            assert(!map.put(4, 3), "");
+            assert(!map.put(5, 3), "");
+            assert(map.put(2, 1), "Failed to update");
+            assert(!map.put(6, 4), "");
+            assert(map.put(6, 4), "");
+
+            assert(map.remove(2), "Failed to remove 2");
+            assert(map.contains(3), "Failed to get 3");
+            assert(map.contains(4), "failed to get 4");
+            assert(map.remove(3), "Failed to remove 3");
+            assert(map.contains(4), "Failed to get 4");
+            assert(map.remove(4), "Failed to remove 4");
+            assert(map.contains(5), "Failed to get 5");
+
+            assert(map.remove(5), "Failed to remove 5");
+            assert(map.contains(6), "Failed to get 6");
+            assert(map.remove(6), "Failed to remove 6");
+            assert(map.entry_count() == 0, "Not empty");
+        }
+
+        {
+            typedef SimpleOpenHashtable<intx, intx, colliding_hash> IntMap;
+
+            IntMap map(1024, DEFAULT_LOAD_FACTOR);
+
+            assert(!map.put(0, 1), "Failed to insert");
+            assert(!map.put(8, 8), "Failed to insert");
+
+            assert(!map.put(8180, 8180), "Failed to insert");
+            assert(!map.put(8184, 8184), "Failed to insert");
+
+            assert(!map.put(8181, 8181), "Failed to insert");
+            assert(!map.put(8182, 8182), "Failed to insert");
+            assert(!map.put(8183, 8183), "Failed to insert");
+
+            assert(7 == map.entry_count(), "Size is 7");
+
+            assert(map.remove(0), "Failed to remove 0");
+
+            assert(map.get(8) == 8, "Failed to get");
+            assert(map.get(8180) == 8180, "Failed to get");
+            assert(map.get(8181) == 8181, "Failed to get");
+            assert(map.get(8182) == 8182, "Failed to get");
+            assert(map.get(8183) == 8183, "Failed to get");
+            assert(map.get(8184) == 8184, "Failed to get");
+
+            assert(map.remove(8180), "Failed to remove 8180");
+            assert(map.remove(8181), "Failed to remove 8181");
+
+            assert(map.get(8) == 8, "Failed to get");
+            assert(map.get(8182) == 8182, "Failed to get");
+            assert(map.get(8183) == 8183, "Failed to get");
+            assert(map.get(8184) == 8184, "Failed to get");
+
+            assert(map.remove(8184), "Failed to remove 8184");
+
+            assert(map.get(8) == 8, "Failed to get");
+            assert(map.get(8182) == 8182, "Failed to get");
+            assert(map.get(8183) == 8183, "Failed to get");
+        }
+
+        {
+            Runner<>::test_small();
+            Runner<>::test_small_shifted();
+            Runner<>::test(16);
+            Runner<>::test(128);
+            Runner<>::test(256);
+            Runner<>::test(512);
+        }
+
+        {
+            Runner<identity_hash>::test_small();
+            Runner<identity_hash>::test_small_shifted();
+            Runner<identity_hash>::test(16);
+            Runner<identity_hash>::test(128);
+            Runner<identity_hash>::test(256);
+            Runner<identity_hash>::test(512);
+        }
+
+        {
+            Runner<bad_hash>::test_small();
+            Runner<bad_hash>::test_small_shifted();
+            Runner<bad_hash>::test(16);
+            Runner<bad_hash>::test(128);
+            Runner<bad_hash>::test(256);
+            Runner<bad_hash>::test(512);
+        }
+    }
+};
+
+void TestSimpleHashtable_test() {
+  TestSimpleHashtable::run_tests();
+}
+
+#endif // not PRODUCT

--- a/src/jdk/make/mapfiles/libmanagement/mapfile-vers
+++ b/src/jdk/make/mapfiles/libmanagement/mapfile-vers
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -83,6 +83,7 @@ SUNWprivate_1.1 {
 	    Java_sun_management_ThreadImpl_getThreadTotalCpuTime1;
 	    Java_sun_management_ThreadImpl_getThreadUserCpuTime0;
 	    Java_sun_management_ThreadImpl_getThreadUserCpuTime1;
+	    Java_sun_management_ThreadImpl_getThreadAllocatedMemory0;
 	    Java_sun_management_ThreadImpl_getThreadAllocatedMemory1;
 	    Java_sun_management_ThreadImpl_resetContentionTimes0;
 	    Java_sun_management_ThreadImpl_resetPeakThreadCount0;

--- a/src/jdk/src/share/classes/com/sun/management/ThreadMXBean.java
+++ b/src/jdk/src/share/classes/com/sun/management/ThreadMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @throws NullPointerException if {@code ids} is {@code null}
      * @throws IllegalArgumentException if any element in the input array
      *         {@code ids} is {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      *         virtual machine implementation does not support CPU time
      *         measurement.
      *
@@ -96,7 +96,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @throws NullPointerException if {@code ids} is {@code null}
      * @throws IllegalArgumentException if any element in the input array
      *         {@code ids} is {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      *         virtual machine implementation does not support CPU time
      *         measurement.
      *
@@ -110,13 +110,50 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
 
     /**
      * Returns an approximation of the total amount of memory, in bytes,
-     * allocated in heap memory for the thread of the specified ID.
+     * allocated in heap memory for the current thread.
+     * The returned value is an approximation because some Java virtual machine
+     * implementations may use object allocation mechanisms that result in a
+     * delay between the time an object is allocated and the time its size is
+     * recorded.
+     *
+     * <p>
+     * This is a convenience method for local management use and is
+     * equivalent to calling:
+     * <blockquote><pre>
+     *   {@link #getThreadAllocatedBytes getThreadAllocatedBytes}(Thread.currentThread().getId());
+     * </pre></blockquote>
+     *
+     * @implSpec The default implementation throws
+     * {@code UnsupportedOperationException}.
+     *
+     * @return an approximation of the total memory allocated, in bytes, in
+     * heap memory for the current thread
+     * if thread memory allocation measurement is enabled;
+     * {@code -1} otherwise.
+     *
+     * @throws UnsupportedOperationException if the Java virtual
+     *         machine implementation does not support thread memory allocation
+     *         measurement.
+     *
+     * @see #isThreadAllocatedMemorySupported
+     * @see #isThreadAllocatedMemoryEnabled
+     * @see #setThreadAllocatedMemoryEnabled
+     *
+     * @since 14
+     */
+    public default long getCurrentThreadAllocatedBytes() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns an approximation of the total amount of memory, in bytes,
+     * allocated in heap memory for the thread with the specified ID.
      * The returned value is an approximation because some Java virtual machine
      * implementations may use object allocation mechanisms that result in a
      * delay between the time an object is allocated and the time its size is
      * recorded.
      * <p>
-     * If the thread of the specified ID is not alive or does not exist,
+     * If the thread with the specified ID is not alive or does not exist,
      * this method returns {@code -1}. If thread memory allocation measurement
      * is disabled, this method returns {@code -1}.
      * A thread is alive if it has been started and has not yet died.
@@ -128,13 +165,13 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      *
      * @param id the thread ID of a thread
      * @return an approximation of the total memory allocated, in bytes, in
-     * heap memory for a thread of the specified ID
-     * if the thread of the specified ID exists, the thread is alive,
+     * heap memory for the thread with the specified ID
+     * if the thread with the specified ID exists, the thread is alive,
      * and thread memory allocation measurement is enabled;
      * {@code -1} otherwise.
      *
      * @throws IllegalArgumentException if {@code id} {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine implementation does not support thread memory allocation
      *         measurement.
      *
@@ -166,7 +203,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @throws NullPointerException if {@code ids} is {@code null}
      * @throws IllegalArgumentException if any element in the input array
      *         {@code ids} is {@code <=} {@code 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine implementation does not support thread memory allocation
      *         measurement.
      *
@@ -195,7 +232,7 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @return {@code true} if thread memory allocation measurement is enabled;
      *         {@code false} otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine does not support thread memory allocation measurement.
      *
      * @see #isThreadAllocatedMemorySupported
@@ -209,10 +246,10 @@ public interface ThreadMXBean extends java.lang.management.ThreadMXBean {
      * @param enable {@code true} to enable;
      *               {@code false} to disable.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      *         machine does not support thread memory allocation measurement.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *

--- a/src/jdk/src/share/classes/java/lang/management/ThreadMXBean.java
+++ b/src/jdk/src/share/classes/java/lang/management/ThreadMXBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,7 +160,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @return an array of <tt>long</tt>, each is a thread ID.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      */
@@ -199,7 +199,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * it does not exist.
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      */
@@ -237,7 +237,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @throws IllegalArgumentException if any element in the input array
      *         <tt>ids</tt> is {@code <= 0}.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      */
@@ -284,7 +284,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
      * @throws IllegalArgumentException if <tt>maxDepth is negative</tt>.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      *
@@ -337,7 +337,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @throws IllegalArgumentException if <tt>maxDepth is negative</tt>.
      * @throws IllegalArgumentException if any element in the input array
      *      <tt>ids</tt> is {@code <= 0}.
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      *
@@ -360,7 +360,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return <tt>true</tt> if thread contention monitoring is enabled;
      *         <tt>false</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      * machine does not support thread contention monitoring.
      *
      * @see #isThreadContentionMonitoringSupported
@@ -374,10 +374,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @param enable <tt>true</tt> to enable;
      *               <tt>false</tt> to disable.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support thread contention monitoring.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *
@@ -403,7 +403,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return the total CPU time for the current thread if CPU time
      * measurement is enabled; <tt>-1</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * the current thread.
      *
@@ -430,7 +430,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return the user-level CPU time for the current thread if CPU time
      * measurement is enabled; <tt>-1</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * the current thread.
      *
@@ -467,7 +467,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * <tt>-1</tt> otherwise.
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * other threads.
      *
@@ -502,7 +502,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * <tt>-1</tt> otherwise.
      *
      * @throws IllegalArgumentException if {@code id <= 0}.
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * other threads.
      *
@@ -548,7 +548,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return <tt>true</tt> if thread CPU time measurement is enabled;
      *         <tt>false</tt> otherwise.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      * machine does not support CPU time measurement for other threads
      * nor for the current thread.
      *
@@ -564,11 +564,11 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @param enable <tt>true</tt> to enable;
      *               <tt>false</tt> to disable.
      *
-     * @throws java.lang.UnsupportedOperationException if the Java
+     * @throws UnsupportedOperationException if the Java
      * virtual machine does not support CPU time measurement for
      * any threads nor for the current thread.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *
@@ -604,7 +604,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * @return an array of IDs of the threads that are monitor
      * deadlocked, if any; <tt>null</tt> otherwise.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
      *
@@ -616,7 +616,7 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * Resets the peak thread count to the current number of
      * live threads.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("control").
      *
@@ -642,10 +642,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * deadlocked waiting for object monitors or ownable synchronizers, if any;
      * <tt>null</tt> otherwise.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
-     * @throws java.lang.UnsupportedOperationException if the Java virtual
+     * @throws UnsupportedOperationException if the Java virtual
      * machine does not support monitoring of ownable synchronizer usage.
      *
      * @see #isSynchronizerUsageSupported
@@ -743,10 +743,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      * information about a thread whose ID is in the corresponding
      * element of the input array of IDs.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
-     * @throws java.lang.UnsupportedOperationException
+     * @throws UnsupportedOperationException
      *         <ul>
      *           <li>if <tt>lockedMonitors</tt> is <tt>true</tt> but
      *               the Java virtual machine does not support monitoring
@@ -782,10 +782,10 @@ public interface ThreadMXBean extends PlatformManagedObject {
      *
      * @return an array of {@link ThreadInfo} for all live threads.
      *
-     * @throws java.lang.SecurityException if a security manager
+     * @throws SecurityException if a security manager
      *         exists and the caller does not have
      *         ManagementPermission("monitor").
-     * @throws java.lang.UnsupportedOperationException
+     * @throws UnsupportedOperationException
      *         <ul>
      *           <li>if <tt>lockedMonitors</tt> is <tt>true</tt> but
      *               the Java virtual machine does not support monitoring

--- a/src/jdk/src/share/classes/sun/management/ThreadImpl.java
+++ b/src/jdk/src/share/classes/sun/management/ThreadImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,9 @@
 package sun.management;
 
 import java.lang.management.ManagementFactory;
-
 import java.lang.management.ThreadInfo;
-
 import javax.management.ObjectName;
+import java.util.Objects;
 
 /**
  * Implementation class for the thread subsystem.
@@ -105,11 +104,15 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
         return cpuTimeEnabled;
     }
 
-    public boolean isThreadAllocatedMemoryEnabled() {
+    private void ensureThreadAllocatedMemorySupported() {
         if (!isThreadAllocatedMemorySupported()) {
             throw new UnsupportedOperationException(
-                "Thread allocated memory measurement is not supported");
+                "Thread allocated memory measurement is not supported.");
         }
+    }
+
+    public boolean isThreadAllocatedMemoryEnabled() {
+        ensureThreadAllocatedMemorySupported();
         return allocatedMemoryEnabled;
     }
 
@@ -144,16 +147,18 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
         return getThreadInfo(ids, 0);
     }
 
-    private void verifyThreadIds(long[] ids) {
-        if (ids == null) {
-            throw new NullPointerException("Null ids parameter.");
+    private void verifyThreadId(long id) {
+        if (id <= 0) {
+            throw new IllegalArgumentException(
+                "Invalid thread ID parameter: " + id);
         }
+    }
+
+    private void verifyThreadIds(long[] ids) {
+        Objects.requireNonNull(ids);
 
         for (int i = 0; i < ids.length; i++) {
-            if (ids[i] <= 0) {
-                throw new IllegalArgumentException(
-                    "Invalid thread ID parameter: " + ids[i]);
-            }
+            verifyThreadId(ids[i]);
         }
     }
 
@@ -324,26 +329,41 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
         }
     }
 
+    public long getCurrentThreadAllocatedBytes() {
+        if (isThreadAllocatedMemoryEnabled()) {
+            return getThreadAllocatedMemory0(0);
+        }
+        return -1;
+    }
+
+    private boolean verifyThreadAllocatedMemory(long id) {
+        verifyThreadId(id);
+        return isThreadAllocatedMemoryEnabled();
+    }
+
     public long getThreadAllocatedBytes(long id) {
-        long[] ids = new long[1];
-        ids[0] = id;
-        final long[] sizes = getThreadAllocatedBytes(ids);
-        return sizes[0];
+        boolean verified = verifyThreadAllocatedMemory(id);
+
+        if (verified) {
+            return getThreadAllocatedMemory0(
+                Thread.currentThread().getId() == id ? 0 : id);
+        }
+        return -1;
     }
 
     private boolean verifyThreadAllocatedMemory(long[] ids) {
         verifyThreadIds(ids);
-
-        // check if Thread allocated memory measurement is supported.
-        if (!isThreadAllocatedMemorySupported()) {
-            throw new UnsupportedOperationException(
-                "Thread allocated memory measurement is not supported.");
-        }
-
         return isThreadAllocatedMemoryEnabled();
     }
 
     public long[] getThreadAllocatedBytes(long[] ids) {
+        Objects.requireNonNull(ids);
+
+        if (ids.length == 1) {
+            long size = getThreadAllocatedBytes(ids[0]);
+            return new long[] { size };
+        }
+
         boolean verified = verifyThreadAllocatedMemory(ids);
 
         long[] sizes = new long[ids.length];
@@ -356,10 +376,7 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
     }
 
     public void setThreadAllocatedMemoryEnabled(boolean enable) {
-        if (!isThreadAllocatedMemorySupported()) {
-            throw new UnsupportedOperationException(
-                "Thread allocated memory measurement is not supported.");
-        }
+        ensureThreadAllocatedMemorySupported();
 
         Util.checkControlAccess();
         synchronized (this) {
@@ -463,6 +480,7 @@ class ThreadImpl implements com.sun.management.ThreadMXBean {
     private static native void getThreadTotalCpuTime1(long[] ids, long[] result);
     private static native long getThreadUserCpuTime0(long id);
     private static native void getThreadUserCpuTime1(long[] ids, long[] result);
+    private static native long getThreadAllocatedMemory0(long id);
     private static native void getThreadAllocatedMemory1(long[] ids, long[] result);
     private static native void setThreadCpuTimeEnabled0(boolean enable);
     private static native void setThreadAllocatedMemoryEnabled0(boolean enable);

--- a/src/jdk/src/share/javavm/export/jmm.h
+++ b/src/jdk/src/share/javavm/export/jmm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,6 +243,9 @@ typedef struct jmmInterface_1_ {
   jobject      (JNICALL *GetMemoryPoolUsage)     (JNIEnv* env, jobject pool);
   jobject      (JNICALL *GetPeakMemoryPoolUsage) (JNIEnv* env, jobject pool);
 
+  jlong        (JNICALL *GetOneThreadAllocatedMemory)
+                                                 (JNIEnv *env,
+                                                  jlong thread_id);
   void         (JNICALL *GetThreadAllocatedMemory)
                                                  (JNIEnv *env,
                                                   jlongArray ids,

--- a/src/jdk/src/share/native/sun/font/freetypeScaler.c
+++ b/src/jdk/src/share/native/sun/font/freetypeScaler.c
@@ -559,6 +559,14 @@ Java_sun_font_FreetypeFontScaler_getFontMetricsNative(
     /* See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=657854 */
 #define FT_MulFixFloatShift6(a, b) (((float) (a)) * ((float) (b)) / 65536.0 / 64.0)
 
+#define contextAwareMetricsX(x, y) \
+    (FTFixedToFloat(context->transform.xx) * (x) - \
+     FTFixedToFloat(context->transform.xy) * (y))
+
+#define contextAwareMetricsY(x, y) \
+    (-FTFixedToFloat(context->transform.yx) * (x) + \
+     FTFixedToFloat(context->transform.yy) * (y))
+
     /*
      * See FreeType source code: src/base/ftobjs.c ft_recompute_scaled_metrics()
      * http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=1659
@@ -591,9 +599,13 @@ Java_sun_font_FreetypeFontScaler_getFontMetricsNative(
     my = 0;
 
     metrics = (*env)->NewObject(env,
-                                sunFontIDs.strikeMetricsClass,
-                                sunFontIDs.strikeMetricsCtr,
-                                ax, ay, dx, dy, bx, by, lx, ly, mx, my);
+        sunFontIDs.strikeMetricsClass,
+        sunFontIDs.strikeMetricsCtr,
+        contextAwareMetricsX(ax, ay), contextAwareMetricsY(ax, ay),
+        contextAwareMetricsX(dx, dy), contextAwareMetricsY(dx, dy),
+        bx, by,
+        contextAwareMetricsX(lx, ly), contextAwareMetricsY(lx, ly),
+        contextAwareMetricsX(mx, my), contextAwareMetricsY(mx, my));
 
     return metrics;
 }

--- a/src/jdk/src/share/native/sun/management/ThreadImpl.c
+++ b/src/jdk/src/share/native/sun/management/ThreadImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,6 +92,13 @@ Java_sun_management_ThreadImpl_getThreadUserCpuTime1
 {
     jmm_interface->GetThreadCpuTimesWithKind(env, ids, timeArray,
                                              JNI_FALSE /* user */);
+}
+
+JNIEXPORT jlong JNICALL
+Java_sun_management_ThreadImpl_getThreadAllocatedMemory0
+  (JNIEnv *env, jclass cls, jlong tid)
+{
+  return jmm_interface->GetOneThreadAllocatedMemory(env, tid);
 }
 
 JNIEXPORT void JNICALL

--- a/src/jdk/test/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
+++ b/src/jdk/test/com/sun/management/ThreadMXBean/ThreadAllocatedMemory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug     6173675
+ * @bug     6173675 8231209
  * @summary Basic test of ThreadMXBean.getThreadAllocatedBytes
  * @author  Paul Hohensee
  */
@@ -33,9 +33,8 @@ import java.lang.management.*;
 public class ThreadAllocatedMemory {
     private static com.sun.management.ThreadMXBean mbean =
         (com.sun.management.ThreadMXBean)ManagementFactory.getThreadMXBean();
-    private static boolean testFailed = false;
-    private static boolean done = false;
-    private static boolean done1 = false;
+    private static volatile boolean done = false;
+    private static volatile boolean done1 = false;
     private static Object obj = new Object();
     private static final int NUM_THREADS = 10;
     private static Thread[] threads = new Thread[NUM_THREADS];
@@ -44,6 +43,22 @@ public class ThreadAllocatedMemory {
     public static void main(String[] argv)
         throws Exception {
 
+        testSupportEnableDisable();
+
+        // Test current thread two ways
+        testGetCurrentThreadAllocatedBytes();
+        testCurrentThreadGetThreadAllocatedBytes();
+
+        // Test a single thread that is not this one
+        testGetThreadAllocatedBytes();
+
+        // Test many threads that are not this one
+        testGetThreadsAllocatedBytes();
+
+        System.out.println("Test passed");
+    }
+
+    private static void testSupportEnableDisable() {
         if (!mbean.isThreadAllocatedMemorySupported()) {
             return;
         }
@@ -58,10 +73,7 @@ public class ThreadAllocatedMemory {
                 "ThreadAllocatedMemory is expected to be disabled");
         }
 
-        Thread curThread = Thread.currentThread();
-        long id = curThread.getId();
-
-        long s = mbean.getThreadAllocatedBytes(id);
+        long s = mbean.getCurrentThreadAllocatedBytes();
         if (s != -1) {
             throw new RuntimeException(
                 "Invalid ThreadAllocatedBytes returned = " +
@@ -77,63 +89,106 @@ public class ThreadAllocatedMemory {
             throw new RuntimeException(
                 "ThreadAllocatedMemory is expected to be enabled");
         }
+    }
 
-        long size = mbean.getThreadAllocatedBytes(id);
-        // implementation could have started measurement when
-        // measurement was enabled, in which case size can be 0
-        if (size < 0) {
-            throw new RuntimeException(
-                "Invalid allocated bytes returned = " + size);
-        }
+    private static void testGetCurrentThreadAllocatedBytes() {
+        long size = mbean.getCurrentThreadAllocatedBytes();
+        ensureValidSize(size);
 
+        // do some more allocation
         doit();
 
-        // Expected to be size1 >= size
-        long size1 = mbean.getThreadAllocatedBytes(id);
-        if (size1 < size) {
-            throw new RuntimeException("Allocated bytes " + size1 +
-                " expected >= " + size);
-        }
-        System.out.println(curThread.getName() +
-            " Current thread allocated bytes = " + size +
-            " allocated bytes = " + size1);
+        checkResult(Thread.currentThread(), size,
+                    mbean.getCurrentThreadAllocatedBytes());
+    }
 
+    private static void testCurrentThreadGetThreadAllocatedBytes() {
+        Thread curThread = Thread.currentThread();
+        long id = curThread.getId();
 
-        // start threads, wait for them to block
-        for (int i = 0; i < NUM_THREADS; i++) {
-            threads[i] = new MyThread("MyThread-" + i);
-            threads[i].start();
-        }
+        long size = mbean.getThreadAllocatedBytes(id);
+        ensureValidSize(size);
 
-        // threads block after doing some allocation
-        waitUntilThreadBlocked();
+        // do some more allocation
+        doit();
 
-        for (int i = 0; i < NUM_THREADS; i++) {
-            sizes[i] = mbean.getThreadAllocatedBytes(threads[i].getId());
-        }
+        checkResult(curThread, size, mbean.getThreadAllocatedBytes(id));
+    }
 
-        // let threads go and do some more allocation
+    private static void testGetThreadAllocatedBytes()
+        throws Exception {
+
+        // start a thread
+        done = false; done1 = false;
+        Thread curThread = new MyThread("MyThread");
+        curThread.start();
+        long id = curThread.getId();
+
+        // wait for thread to block after doing some allocation
+        waitUntilThreadBlocked(curThread);
+
+        long size = mbean.getThreadAllocatedBytes(id);
+        ensureValidSize(size);
+
+        // let thread go to do some more allocation
         synchronized (obj) {
             done = true;
             obj.notifyAll();
         }
 
-        // wait for threads to get going again.  we don't care if we
+        // wait for thread to get going again. we don't care if we
+        // catch it in mid-execution or if it hasn't
+        // restarted after we're done sleeping.
+        goSleep(400);
+
+        checkResult(curThread, size, mbean.getThreadAllocatedBytes(id));
+
+        // let thread exit
+        synchronized (obj) {
+            done1 = true;
+            obj.notifyAll();
+        }
+
+        try {
+            curThread.join();
+        } catch (InterruptedException e) {
+            System.out.println("Unexpected exception is thrown.");
+            e.printStackTrace(System.out);
+        }
+    }
+
+    private static void testGetThreadsAllocatedBytes()
+        throws Exception {
+
+        // start threads
+        done = false; done1 = false;
+        for (int i = 0; i < NUM_THREADS; i++) {
+            threads[i] = new MyThread("MyThread-" + i);
+            threads[i].start();
+        }
+
+        // wait for threads to block after doing some allocation
+        waitUntilThreadsBlocked();
+
+        for (int i = 0; i < NUM_THREADS; i++) {
+            sizes[i] = mbean.getThreadAllocatedBytes(threads[i].getId());
+            ensureValidSize(sizes[i]);
+        }
+
+        // let threads go to do some more allocation
+        synchronized (obj) {
+            done = true;
+            obj.notifyAll();
+        }
+
+        // wait for threads to get going again. we don't care if we
         // catch them in mid-execution or if some of them haven't
         // restarted after we're done sleeping.
         goSleep(400);
 
         for (int i = 0; i < NUM_THREADS; i++) {
-            long newSize = mbean.getThreadAllocatedBytes(threads[i].getId());
-            if (sizes[i] > newSize) {
-                throw new RuntimeException("TEST FAILED: " +
-                    threads[i].getName() +
-                    " previous allocated bytes = " + sizes[i] +
-                    " > current allocated bytes = " + newSize);
-            }
-            System.out.println(threads[i].getName() +
-                " Previous allocated bytes = " + sizes[i] +
-                " Current allocated bytes = " + newSize);
+            checkResult(threads[i], sizes[i],
+                        mbean.getThreadAllocatedBytes(threads[i].getId()));
         }
 
         // let threads exit
@@ -148,17 +203,30 @@ public class ThreadAllocatedMemory {
             } catch (InterruptedException e) {
                 System.out.println("Unexpected exception is thrown.");
                 e.printStackTrace(System.out);
-                testFailed = true;
                 break;
             }
         }
-        if (testFailed) {
-            throw new RuntimeException("TEST FAILED");
-        }
-
-        System.out.println("Test passed");
     }
 
+    private static void ensureValidSize(long size) {
+        // implementation could have started measurement when
+        // measurement was enabled, in which case size can be 0
+        if (size < 0) {
+            throw new RuntimeException(
+                "Invalid allocated bytes returned = " + size);
+        }
+    }
+
+    private static void checkResult(Thread curThread,
+                                    long prev_size, long curr_size) {
+        if (curr_size < prev_size) {
+            throw new RuntimeException("Allocated bytes " + curr_size +
+                                       " expected >= " + prev_size);
+        }
+        System.out.println(curThread.getName() +
+                           " Previous allocated bytes = " + prev_size +
+                           " Current allocated bytes = " + curr_size);
+    }
 
     private static void goSleep(long ms) throws Exception {
         try {
@@ -169,7 +237,18 @@ public class ThreadAllocatedMemory {
         }
     }
 
-    private static void waitUntilThreadBlocked()
+    private static void waitUntilThreadBlocked(Thread thread)
+        throws Exception {
+        while (true) {
+            goSleep(100);
+            ThreadInfo info = mbean.getThreadInfo(thread.getId());
+            if (info.getThreadState() == Thread.State.WAITING) {
+                break;
+            }
+        }
+    }
+
+    private static void waitUntilThreadsBlocked()
         throws Exception {
         int count = 0;
         while (count != NUM_THREADS) {
@@ -210,7 +289,6 @@ public class ThreadAllocatedMemory {
                     } catch (InterruptedException e) {
                         System.out.println("Unexpected exception is thrown.");
                         e.printStackTrace(System.out);
-                        testFailed = true;
                         break;
                     }
                 }
@@ -225,7 +303,7 @@ public class ThreadAllocatedMemory {
                 " ThreadAllocatedBytes  = " + size2);
 
             if (size1 > size2) {
-                throw new RuntimeException("TEST FAILED: " + getName() +
+                throw new RuntimeException(getName() +
                     " ThreadAllocatedBytes = " + size1 +
                     " > ThreadAllocatedBytes = " + size2);
             }
@@ -237,7 +315,6 @@ public class ThreadAllocatedMemory {
                     } catch (InterruptedException e) {
                         System.out.println("Unexpected exception is thrown.");
                         e.printStackTrace(System.out);
-                        testFailed = true;
                         break;
                     }
                 }

--- a/src/jdk/test/java/awt/font/Rotate/RotatedFontMetricsTest.java
+++ b/src/jdk/test/java/awt/font/Rotate/RotatedFontMetricsTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test    RotatedFontMetricsTest
+ * @bug     8139178
+ * @summary This test verifies that rotation does not affect font metrics.
+ * @run     main RotatedFontMetricsTest
+ */
+
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+public class RotatedFontMetricsTest {
+    static final int FONT_SIZE = Integer.getInteger("font.size", 20);
+
+    public static void main(String ... args) {
+        Font font = new Font(Font.DIALOG, Font.PLAIN, FONT_SIZE);
+        Graphics2D g2d = createGraphics();
+
+        FontMetrics ref = null;
+        RuntimeException failure = null;
+        for (int a = 0; a < 360; a += 15) {
+            Graphics2D g = (Graphics2D)g2d.create();
+            g.rotate(Math.toRadians(a));
+            FontMetrics m = g.getFontMetrics(font);
+            g.dispose();
+
+            boolean status = true;
+            if (ref == null) {
+                ref = m;
+            } else {
+                status = ref.getAscent() == m.getAscent() &&
+                        ref.getDescent() == m.getDescent() &&
+                        ref.getLeading() == m.getLeading() &&
+                        ref.getMaxAdvance() == m.getMaxAdvance();
+            }
+
+            System.out.printf("Metrics a%d, d%d, l%d, m%d (%d) %s\n",
+                    m.getAscent(), m.getDescent(), m.getLeading(), m.getMaxAdvance(),
+                    (int)a, status ? "OK" : "FAIL");
+
+            if (!status && failure == null) {
+                failure = new RuntimeException("Font metrics differ for angle " + a);
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
+        System.out.println("done");
+    }
+
+    private static Graphics2D createGraphics() {
+        BufferedImage dst = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB);
+        return dst.createGraphics();
+    }
+}


### PR DESCRIPTION
### Description
Backport of JDK-8139178 from JDK12.

Validated on linux using cups-pdf, fontMetrics return 0 unless this patch is applied.


### Motivation and context
This is an old bug exclusive to the open source font engine of OpenJDK.


### How has this been tested?
Passed Tier1 and Tier2 testing.

