### PR TITLE
[backport]8233839: aarch64: missing memory barrier in NewObjectArrayStub and NewTypeArrayStub

### DIFF
--- a/src/hotspot/src/cpu/aarch64/vm/c1_Runtime1_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/c1_Runtime1_aarch64.cpp
@@ -876,6 +876,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
           __ sub(arr_size, arr_size, t1);  // body length
           __ add(t1, t1, obj);       // body start
           __ initialize_body(t1, arr_size, 0, t2);
+          __ membar(Assembler::StoreStore);
           __ verify_oop(obj);
 
           __ ret(lr);
@@ -904,6 +905,7 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
           __ sub(arr_size, arr_size, t1);  // body length
           __ add(t1, t1, obj);       // body start
           __ initialize_body(t1, arr_size, 0, t2);
+          __ membar(Assembler::StoreStore);
           __ verify_oop(obj);
 
           __ ret(lr);


### PR DESCRIPTION


Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
we observe jcstress have some random failures on aarch64(a1.4x).  It's because c1 misses a membar(StoreStore) in some path of new_type_array.  the problem is described in the related issues. 

### Related issues
JDK-8233839
JDK-8234977

### Motivation and context


### How has this been tested?
yes, hotspot-tier1

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
