### PR TITLE
[backport] 8135018: AARCH64: Missing memory barriers for CMS collector

### DIFF
--- a/src/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/macroAssembler_aarch64.cpp
@@ -3135,6 +3135,10 @@ void MacroAssembler::store_check_part_2(Register obj) {
   // don't bother to check, but it could save an instruction.
   intptr_t disp = (intptr_t) ct->byte_map_base;
   load_byte_map_base(rscratch1);
+
+  if (UseConcMarkSweepGC && CMSPrecleaningEnabled) {
+      membar(StoreStore);
+  }
   strb(zr, Address(obj, rscratch1));
 }
 

--- a/src/hotspot/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
+++ b/src/hotspot/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp
@@ -678,6 +678,9 @@ class StubGenerator: public StubCodeGenerator {
           const Register count = end; // 'end' register contains bytes count now
           __ load_byte_map_base(scratch);
           __ add(start, start, scratch);
+          if (UseConcMarkSweepGC) {
+            __ membar(__ StoreStore);
+          }
 	  __ BIND(L_loop);
 	  __ strb(zr, Address(start, count));
           __ subs(count, count, 1);

--- a/src/hotspot/src/share/vm/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/src/share/vm/c1/c1_LIRGenerator.cpp
@@ -1607,6 +1607,11 @@ void LIRGenerator::CardTableModRef_post_barrier(LIR_OprDesc* addr, LIR_OprDesc* 
   } else {
     __ unsigned_shift_right(addr, CardTableModRefBS::card_shift, tmp);
   }
+
+  if (UseConcMarkSweepGC && CMSPrecleaningEnabled) {
+    __ membar_storestore();
+  }
+
   if (can_inline_as_constant(card_table_base)) {
     __ move(LIR_OprFact::intConst(0),
               new LIR_Address(tmp, card_table_base->as_jint(), T_BYTE));


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
fix a bug for CMS on aarch64. 
C1 and template interpreter both miss a StoreStore membar between put_field and updateCardTable. 

### Related issues


### Motivation and context


### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
