### PR TITLE
Fix compilation error in simpleOpenHashtable when precompiled headers are disabled

### DIFF
--- a/src/hotspot/src/share/vm/utilities/simpleOpenHashtable.hpp
+++ b/src/hotspot/src/share/vm/utilities/simpleOpenHashtable.hpp
@@ -26,6 +26,7 @@
 #define SHARE_VM_UTILITIES_SIMPLEOPENHASHTABLE_HPP
 
 #include "memory/allocation.hpp"
+#include "memory/allocation.inline.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/hashFns.hpp"
 #include "utilities/globalDefinitions.hpp"


### PR DESCRIPTION
This error is observed in macOS build with flag `--disable-precompiled-headers`.

Build tested on macOS w/ or w/o `--disable-precompiled-headers`.