### PR TITLE
Support debug build and refactor common gradle logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@
 // property. For an example of its usage, see ':installers:linux:rpm:buildLogic'
 // where the version numbers are used to populate a templated RPM spec file.
 
+import org.apache.tools.ant.taskdefs.condition.Os
+
 allprojects {
     apply plugin: 'base'
 
@@ -62,6 +64,96 @@ allprojects {
                     'wsgen', 'wsimport', 'xjc']
         jreTools = ['java', 'jjs', 'keytool', 'orbd', 'pack200', 'policytool', 'rmid', 'rmiregistry',
                     'servertool', 'tnameserv', 'unpack200']
+
+        correttoCommonFlags = [
+                "--with-update-version=${project.version.update}",
+                "--with-build-number=b${project.version.build}",
+                "--with-corretto-revision=${project.version.revision}",
+                '--with-milestone=fcs',
+                '--with-vendor-name=Amazon.com Inc.',
+                '--with-vendor-url=https://aws.amazon.com/corretto/',
+                "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/"
+        ]
+
+        // Valid value: null, release, debug, fastdebug, slowdebug
+        def correttoDebugLevel = "release" // Default: release
+        switch(project.findProperty("corretto.debug_level")) {
+            case null:
+            case "release":
+                correttoCommonFlags += ['--disable-debug-symbols', '--disable-zip-debug-info']
+                break
+            case "fastdebug":
+                correttoDebugLevel = "fastdebug"
+                correttoCommonFlags += ['--with-debug-level=fastdebug']
+                break
+            case "debug":
+            case "slowdebug":
+                correttoDebugLevel = "slowdebug"
+                correttoCommonFlags += ['--with-debug-level=slowdebug', '--disable-zip-debug-info']
+                break
+            default:
+                throw new RuntimeException("Invalid corretto.debug_level")
+        }
+
+        // customized flags. Identify the index of double dashes as the start of a flag
+        String extraConfig = project.findProperty("corretto.extra_config")
+        def lastIndex = -1
+        if (extraConfig != null) {
+            for (int index = extraConfig.indexOf("--"); index >= 0; index = extraConfig.indexOf("--", index + 1)) {
+                if (lastIndex != -1) {
+                    correttoCommonFlags += extraConfig.substring(lastIndex, index).trim()
+                }
+                lastIndex = index
+            }
+            if (lastIndex != -1) {
+                correttoCommonFlags += extraConfig.substring(lastIndex).trim()
+            }
+        }
+
+        // Determine the system architecture
+        def jdkArch = ""
+        def os = ""
+        if (Os.isFamily(Os.FAMILY_MAC)) {
+            os = 'macosx'
+            jdkArch = "x86_64"
+        } else if (Os.isFamily(Os.FAMILY_UNIX)) {
+            os = 'linux'
+            jdkArch = ['uname', '-m'].execute().text.trim()
+        } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+            os = 'windows'
+            def arch = System.getenv('PROCESSOR_ARCHITECTURE')
+            if (arch == 'AMD64') {
+                jdkArch = "x86_64"
+            } else { //x86
+                jdkArch = arch
+            }
+        } else {
+            throw new GradleException("OS is not supported")
+        }
+
+        // Ext property: correttoArch
+        switch (jdkArch) {
+            case 'x86':
+            case 'aarch64':
+                correttoArch = jdkArch
+                break
+            case 'x86_64':
+                correttoArch = 'x64'
+                break
+            default:
+                throw new GradleException("${jdkArch} is not supported")
+        }
+
+        // Call toString explicitly to avoid lazy evaluation
+        jdkImageName = "${os}-${jdkArch}-normal-server-${correttoDebugLevel}".toString()
+        // no debug level suffix for release build
+        if (correttoDebugLevel == "release") {
+            correttoJdkArchiveName = "amazon-corretto-${project.version.full}-${os}-${correttoArch}".toString()
+        } else {
+            correttoJdkArchiveName =
+                    "amazon-corretto-${project.version.full}-${os}-${correttoArch}-${correttoDebugLevel}".toString()
+        }
+
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed May 13 08:33:59 PDT 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -28,29 +28,24 @@ dependencies {
 }
 
 ext {
-    // all linux distros and macos support 'uname -m'
-    arch = ['uname', '-m'].execute().text.trim()
-
-    switch (arch) {
+    // project.correttoArch has been verified in the root project
+    // No need to set default
+    switch (project.correttoArch) {
         case 'aarch64':
-            arch_alias = arch
             // Ubuntu arch designation for 64bit ARM is arm64
             arch_deb = 'arm64'
             break
-        case 'x86_64':
-            arch_alias = 'x64'
+        case 'x64':
             // Ubuntu arch designation for AMD64 & Intel 64 is amd64
             arch_deb = 'amd64'
             break
-        default:
-            throw new GradleException("${arch} is not suported")
     }
 }
 
 def jvmDir = '/usr/lib/jvm'
 def jdkInstallationDirName = "java-1.${project.version.major}.0-amazon-corretto"
 def jdkHome = "${jvmDir}/${jdkInstallationDirName}".toString()
-def jdkBinaryDir = "${buildRoot}/amazon-corretto-${project.version.full}-linux-${arch_alias}"
+def jdkBinaryDir = "${buildRoot}/${project.correttoJdkArchiveName}"
 def jdkPackageName = "java-1.${project.version.major}.0-amazon-corretto-jdk"
 
 // In trusty repo, openjdk7 has priority 1071 and openjdk6 has 1061

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -27,27 +27,22 @@ dependencies {
 }
 
 ext {
-    // all linux distros and macos support 'uname -m'
-    arch = ['uname', '-m'].execute().text.trim()
-
-    switch (arch) {
+    // project.correttoArch has been verified in the root project
+    // No need to set default
+    switch (project.correttoArch) {
         case 'aarch64':
             arch_redline = 'AARCH64'
-            arch_alias = arch
-            break;
-        case 'x86_64':
-            arch_redline = arch
-            arch_alias = 'x64'
-            break;
-        default:
-            throw new GradleException("${arch} is not suported")
+            break
+        case 'x64':
+            arch_redline = 'x86_64'
+            break
     }
 }
 
 def jvmDir = '/usr/lib/jvm'
 def jdkInstallationDirName = "java-1.${project.version.major}.0-amazon-corretto"
 def jdkHome = "${jvmDir}/${jdkInstallationDirName}"
-def jdkBinaryDir = "${buildRoot}/amazon-corretto-${project.version.full}-linux-${arch_alias}"
+def jdkBinaryDir = "${buildRoot}/${project.correttoJdkArchiveName}"
 def jdkPackageName = "java-1.${project.version.major}.0-amazon-corretto-devel"
 
 

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -26,25 +26,8 @@ dependencies {
     javafx project(path: ':javafx', configuration: 'archives')
     compile project(path: ':openjdksrc', configuration: 'archives')
 }
-ext {
-    // all linux distros and macos support 'uname -m'
-    arch = ['uname', '-m'].execute().text.trim()
 
-    switch (arch) {
-        case 'aarch64':
-            arch_alias = arch
-            break;
-        case 'x86_64':
-            arch_alias = 'x64'
-            break;
-        default:
-            throw new GradleException("${arch} is not suported")
-    }
-}
-
-def jdkResultingImage = "$buildRoot/src/build/linux-${arch}-normal-server-release/images/j2sdk-image"
-def binaryResultName = "amazon-corretto-${project.version.full}-linux-${arch_alias}"
-def archiveName = "amazon-corretto-${project.version.full}-linux-${arch_alias}.tar.gz"
+def jdkResultingImage = "$buildRoot/src/build/${project.jdkImageName}/images/j2sdk-image"
 
 /**
  * Create a local copy of the source tree in our
@@ -73,17 +56,12 @@ task createJavafxOverlay(type: Copy) {
 task configureBuild(type: Exec) {
     dependsOn copySource
     workingDir "$buildRoot/src"
-    commandLine 'bash', 'configure',
-            "--with-update-version=${project.version.update}",
-            "--with-build-number=b${project.version.build}",
-            "--with-corretto-revision=${project.version.revision}",
-            '--with-milestone=fcs',
-            '--disable-debug-symbols',
-            '--disable-zip-debug-info',
-            'LIBCXX=-static-libstdc++ -static-libgcc',
-            '--with-vendor-name=Amazon.com Inc.',
-            '--with-vendor-url=https://aws.amazon.com/corretto/',
-            "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/"
+    // Platform specific flags
+    def command = ['bash', 'configure',
+            'LIBCXX=-static-libstdc++ -static-libgcc']
+    // Common flags
+    command += project.correttoCommonFlags
+    commandLine command.flatten()
 }
 
 task executeBuild(type: Exec) {
@@ -109,12 +87,12 @@ task copyBuildResults() {
     description 'Copy the JDK image and puts the results in build/.'
     dependsOn executeBuild
     dependsOn importAmazonCacerts
-    if (arch == 'x86_64') {
+    if (project.correttoArch == 'x64') {
         dependsOn createJavafxOverlay
     }
 
     doLast {
-        def destination = "${buildDir}/${binaryResultName}"
+        def destination = "${buildDir}/${project.correttoJdkArchiveName}"
         copy {
             from(buildRoot) {
                 include 'ASSEMBLY_EXCEPTION'
@@ -129,7 +107,7 @@ task copyBuildResults() {
             commandLine 'cp', '-Rf', '--parents', 'bin', 'include', 'jre', 'lib', 'man/man1', 'src.zip', destination
         }
 
-        if (arch == 'x86_64') {
+        if (project.correttoArch == 'x64') {
             exec {
                 workingDir createJavafxOverlay.destinationDir
                 commandLine 'cp', '-Rf', '--parents', 'bin', 'jre', 'lib', 'man/man1', 'javafx-src.zip', destination
@@ -143,7 +121,7 @@ task packageBuildResults(type: Exec) {
     dependsOn copyBuildResults
     outputs.dir distributionDir
     workingDir buildDir
-    commandLine 'tar', 'cfz', "${distributionDir}/${archiveName}", binaryResultName
+    commandLine 'tar', 'cfz', "${distributionDir}/${project.correttoJdkArchiveName}.tar.gz", project.correttoJdkArchiveName
 }
 
 artifacts {

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -28,8 +28,8 @@ dependencies {
     compile project(path: ':openjdksrc', configuration: 'archives')
 }
 
-def jdkResultingImage = "$buildRoot/src/build/macosx-x86_64-normal-server-release/images/j2sdk-bundle"
-def correttoMacDir = 'amazon-corretto-8.jdk'
+def jdkResultingImage = "$buildRoot/src/build/${project.jdkImageName}/images/j2sdk-bundle"
+def correttoMacDir = "amazon-corretto-${project.version.major}.jdk"
 
 /**
  * Create a local copy of the source tree in our
@@ -48,23 +48,13 @@ task copySource(type: Copy) {
 task configureBuild(type: Exec) {
     dependsOn copySource
     workingDir "$buildRoot/src"
-    def commands = ['bash', 'configure',
-            "--with-update-version=${project.version.update}",
-            "--with-build-number=b${project.version.build}",
-            "--with-corretto-revision=${project.version.revision}",
+    // Platform specific flags
+    def command = ['bash', 'configure',
             "--with-toolchain-type=clang",
-            '--with-milestone=fcs',
-            '--with-x',
-            '--disable-debug-symbols',
-            '--disable-zip-debug-info',
-            '--with-vendor-name=Amazon.com Inc.',
-            '--with-vendor-url=https://aws.amazon.com/corretto/',
-            "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/"]
-    def extraCmd = System.getenv("EXTRA_CORRETTO_CONFIG_OPTIONS")
-    if (extraCmd != null) {
-        commands += extraCmd.split(" ")
-    }
-    commandLine commands.flatten()
+            '--with-x']
+    // Common flags
+    command += project.correttoCommonFlags
+    commandLine command.flatten()
 }
 
 task executeBuild(type: Exec) {
@@ -76,7 +66,7 @@ task executeBuild(type: Exec) {
 
 task importAmazonCacerts(type: Exec) {
     dependsOn executeBuild
-    workingDir "${jdkResultingImage}/jdk1.8.0_${project.version.update}.jdk/Contents/Home/"
+    workingDir "${jdkResultingImage}/jdk1.${project.version.major}.0_${project.version.update}.jdk/Contents/Home/"
     // Default password for JSSE key store
     def keystore_password = "changeit"
     commandLine 'keytool', '-importkeystore', '-noprompt',
@@ -89,7 +79,7 @@ task importAmazonCacerts(type: Exec) {
 task renameBuildArtifacts {
     dependsOn importAmazonCacerts
     doLast {
-        file("${jdkResultingImage}/jdk1.8.0_${project.version.update}.jdk").
+        file("${jdkResultingImage}/jdk1.${project.version.major}.0_${project.version.update}.jdk").
                 renameTo(file("${jdkResultingImage}/${correttoMacDir}"))
     }
 }
@@ -157,7 +147,7 @@ task prepareArtifacts {
 
 task packaging(type: Exec) {
     dependsOn prepareArtifacts
-    String tarDir = "${distributionDir}/amazon-corretto-${project.version.full}-macosx-x64.tar.gz"
+    String tarDir = "${distributionDir}/${project.correttoJdkArchiveName}.tar.gz"
     workingDir buildDir
     commandLine "tar", "czf", tarDir, correttoMacDir
     outputs.file tarDir

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -23,23 +23,6 @@ dependencies {
     compile project(path: ':openjdksrc', configuration: 'archives')
 }
 
-ext {
-    arch = System.getenv('PROCESSOR_ARCHITECTURE')
-
-    switch(arch) {
-        case 'x86':
-            arch_alias = 'x86'
-            folder_alias = 'x86'
-            break
-        case 'AMD64':
-            arch_alias = 'x64'
-            folder_alias = 'x86_64'
-            break
-        default:
-            throw new GradleException("${arch} is not suported")
-    }
-}
-
 task copySource(type: Copy) {
     dependsOn project.configurations.compile
     from tarTree(project.configurations.compile.singleFile)
@@ -49,20 +32,14 @@ task copySource(type: Copy) {
 task configureBuild(type: Exec) {
     dependsOn copySource
     workingDir "$buildRoot/src"
-
-    commandLine 'bash', 'configure',
-            "--with-update-version=${project.version.update}",
-            "--with-build-number=b${project.version.build}",
-            "--with-corretto-revision=${project.version.revision}",
-            '--with-milestone=fcs',
-            '--disable-debug-symbols',
-            '--disable-zip-debug-info',
-            '--with-vendor-name=Amazon.com Inc.',
-            '--with-vendor-url=https://aws.amazon.com/corretto/',
-            '--with-vendor-bug-url=https://github.com/corretto/corretto-8/issues/',
+    // Platform specific flags
+    def command = ['bash', 'configure',
             "--with-boot-jdk=${project.getProperty('bootjdk_dir')}",
             "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/msvcr100.dll",
-            "--with-freetype=${project.getProperty('freetype_dir')}"
+            "--with-freetype=${project.getProperty('freetype_dir')}"]
+    // Common flags
+    command += project.correttoCommonFlags
+    commandLine command.flatten()
 }
 
 task executeBuild(type: Exec) {
@@ -74,7 +51,7 @@ task executeBuild(type: Exec) {
 
 task importAmazonCacerts(type: Exec) {
     dependsOn executeBuild
-    workingDir "${executeBuild.workingDir}/build/windows-$folder_alias-normal-server-release/images/j2sdk-image"
+    workingDir "${executeBuild.workingDir}/build/${project.jdkImageName}/images/j2sdk-image"
     // Default password for JSSE key store
     def keystore_password = "changeit"
     commandLine 'keytool', '-importkeystore', '-noprompt',
@@ -86,7 +63,7 @@ task importAmazonCacerts(type: Exec) {
 
 task copyCacerts(type: Copy) {
     dependsOn importAmazonCacerts
-    def imageDir = "${executeBuild.workingDir}/build/windows-$folder_alias-normal-server-release/images"
+    def imageDir = "${executeBuild.workingDir}/build/${project.jdkImageName}/images"
 
     from file("${imageDir}/j2sdk-image/jre/lib/security/cacerts")
     into file("${imageDir}/j2re-image/lib/security")
@@ -95,20 +72,20 @@ task copyCacerts(type: Copy) {
 task copyImage(type: Copy) {
     dependsOn copyCacerts
 
-    from "${executeBuild.workingDir}/build/windows-$folder_alias-normal-server-release/images"
+    from "${executeBuild.workingDir}/build/${project.jdkImageName}/images"
     into "$buildRoot/build"
 }
 
 task packageJdk(type: Zip) {
     dependsOn copyImage
-    archiveName  = "unsigned-jdk-image.${arch_alias}.zip"
+    archiveName  = "unsigned-jdk-image.${project.correttoArch}.zip"
 
     from "$buildRoot/build/j2sdk-image"
 }
 
 task packageJre(type: Zip) {
     dependsOn copyImage
-    archiveName = "unsigned-jre-image.${arch_alias}.zip"
+    archiveName = "unsigned-jre-image.${project.correttoArch}.zip"
 
     from "$buildRoot/build/j2re-image"
 }


### PR DESCRIPTION
Add two properties to control build behavior:
* corretto.debug_level - Control the debug level of the build. Valid options including: release, fastdebug, debug, slowdebug.
* corretto.extra_config - Pass extra configuration flags to the build.

### Tests
* On Linux
```
$ ./gradlew -Pcorretto.debug_level=slowdebug :installers:linux:universal:tar:build
...
A new configuration has been successfully created in
/corretto-8/installers/linux/universal/tar/corretto-build/buildRoot/src/build/linux-x86_64-normal-server-release
using configure arguments 'LIBCXX='-static-libstdc++ -static-libgcc' --with-update-version=252 --with-build-number=b09 --with-corretto-revision=2 --with-milestone=fcs --with-vendor-name='Amazon.com Inc.' --with-vendor-url=https://aws.amazon.com/corretto/ --with-vendor-bug-url=https://github.com/corretto/corretto-8/issues/ --disable-debug-symbols --disable-zip-debug-info'.
...
$ ls installers/linux/universal/tar/corretto-build/distributions/
amazon-corretto-8.252.09.2-linux-x64-slowdebug.tar.gz
```

* On macOS
```
$ ./gradlew -Pcorretto.extra_config="--with-freetype-include=/usr/local/include/freetype2 --with-freetype-lib=/usr/local/lib" -Pcorretto.debug_level=fastdebug :installers:mac:tar:packaging
...
A new configuration has been successfully created in
/corretto/workspace/corretto8-repo/installers/mac/tar/corretto-build/buildRoot/src/build/macosx-x86_64-normal-server-fastdebug
using configure arguments '--with-toolchain-type=clang --with-x --with-update-version=252 --with-build-number=b09 --with-corretto-revision=2 --with-milestone=fcs --with-vendor-name='Amazon.com Inc.' --with-vendor-url=https://aws.amazon.com/corretto/ --with-vendor-bug-url=https://github.com/corretto/corretto-8/issues/ --with-debug-level=fastdebug --with-freetype-include=/usr/local/include/freetype2 --with-freetype-lib=/usr/local/lib'
...
$ ls installers/mac/tar/corretto-build/distributions/
amazon-corretto-8.252.09.2-macosx-x64-fastdebug.tar.gz
$ ./amazon-corretto-8.jdk/Contents/Home/bin/java -version
openjdk version "1.8.0_252-fastdebug"
OpenJDK Runtime Environment Corretto-8.252.09.2 (build 1.8.0_252-fastdebug-b09)
OpenJDK 64-Bit Server VM Corretto-8.252.09.2 (build 25.252-b09-fastdebug, mixed mode)
```