### PR TITLE
Add version.txt to Windows JDK and JRE

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -69,11 +69,26 @@ task copyCacerts(type: Copy) {
     into file("${imageDir}/j2re-image/lib/security")
 }
 
-task copyImage(type: Copy) {
+task copyImage() {
     dependsOn copyCacerts
 
-    from "${executeBuild.workingDir}/build/${project.jdkImageName}/images"
-    into "$buildRoot/build"
+    doLast {
+        // Copy image
+        copy {
+            from "${executeBuild.workingDir}/build/${project.jdkImageName}/images"
+            into "$buildRoot/build"
+        }
+        // Copy version.txt into JDK
+        copy {
+            from "$buildRoot/version.txt"
+            into "$buildRoot/build/j2sdk-image"
+        }
+        // Copy version.txt into JRE
+        copy {
+            from "$buildRoot/version.txt"
+            into "$buildRoot/build/j2re-image"
+        }
+    }
 }
 
 task packageJdk(type: Zip) {


### PR DESCRIPTION
### Description
Corretto 8 Linux and MacOS artifacts have `version.txt` which helps identifying Corretto full version. Add the missing `version.txt` file in Windows JDK and JRE images. 

### How has this been tested?
Build Corretto 8 on Windows build environment and verify `version.txt` present in both JDK and JRE images.



### Platform information
Works on OS: Windows only
