### PR TITLE
Backport JDK-8186090: java.nio.Bits.unaligned() doesn't handle aarch64

### DIFF
--- a/src/jdk/src/share/classes/java/nio/Bits.java
+++ b/src/jdk/src/share/classes/java/nio/Bits.java
@@ -615,7 +615,8 @@ class Bits {                            // package-private
             new sun.security.action.GetPropertyAction("os.arch"));
         unaligned = arch.equals("i386") || arch.equals("x86")
             || arch.equals("amd64") || arch.equals("x86_64")
-            || arch.equals("ppc64") || arch.equals("ppc64le");
+            || arch.equals("ppc64") || arch.equals("ppc64le")
+            || arch.equals("aarch64");
         unalignedKnown = true;
         return unaligned;
     }

--- a/src/jdk/src/share/classes/sun/security/provider/ByteArrayAccess.java
+++ b/src/jdk/src/share/classes/sun/security/provider/ByteArrayAccess.java
@@ -94,7 +94,8 @@ final class ByteArrayAccess {
         String arch = java.security.AccessController.doPrivileged
             (new sun.security.action.GetPropertyAction("os.arch", ""));
         return arch.equals("i386") || arch.equals("x86") || arch.equals("amd64")
-            || arch.equals("x86_64") || arch.equals("ppc64") || arch.equals("ppc64le");
+            || arch.equals("x86_64") || arch.equals("ppc64") || arch.equals("ppc64le")
+            || arch.equals("aarch64");
     }
 
     /**


### PR DESCRIPTION
### Description
This fixes an issue that happened during the import of the aarch64 port from Icedtea due to different implementation of JDK-8158260:

IcedTea: http://icedtea.classpath.org/hg/icedtea8-forest/jdk/rev/bc6eab2038c6
JDK: http://hg.openjdk.java.net/jdk8u/jdk8u/hotspot/rev/6021c95f5944

This led to IcedTea skipping 8186090, but Corretto, which uses the JDK implementation for 8158260, needs it.

### Related issues
**java.nio.Bits.unaligned() doesn't handle aarch64**
https://bugs.openjdk.java.net/browse/JDK-8186090

**PPC64: unaligned Unsafe.getInt can lead to the generation of illegal instructions**
https://bugs.openjdk.java.net/browse/JDK-8158260

