### PR TITLE
Allow passing OpenJFX source location as Gradle property

### DIFF
--- a/javafx/build.gradle
+++ b/javafx/build.gradle
@@ -43,12 +43,23 @@ dependencies {
 }
 
 task unpackSource(type: Copy) {
-    dependsOn configurations.source
-    doFirst {
-        assert openJfxVersion.getProperty('sha256') == sha256(configurations.source.singleFile)
+    if (project.hasProperty("openjfxPath")) {
+        // Get source from local path
+        def openjfx = file("${project.getProperty('openjfxPath')}")
+        doFirst {
+            assert openJfxVersion.getProperty('sha256') == sha256(openjfx)
+        }
+        from tarTree(openjfx)
+        into buildRoot
+    } else {
+        // Get source from HG
+        dependsOn configurations.source
+        doFirst {
+            assert openJfxVersion.getProperty('sha256') == sha256(configurations.source.singleFile)
+        }
+        from tarTree(configurations.source.singleFile)
+        into buildRoot
     }
-    from tarTree(configurations.source.singleFile)
-    into buildRoot
 }
 
 task patchJfx {
@@ -102,3 +113,4 @@ String sha256(File file) {
 artifacts {
     archives packageJfx
 }
+


### PR DESCRIPTION
# Description

OpenJFX project has moved its development repository [jfx-dev/rt ](https://github.com/openjdk/jfx)to Github but the `8u-dev` repository was not included in the migration. We have noticed a couple transient errors when fetching OpenJFX8 source code from hg due to the repository reorganization or availability issue. Here we will allow passing OpenJFX8 source location as Gradle property for such the build won't be impacted by Hg availability.

 
 

### How has this been tested?
Tested full Corretto8 generic Linux build with and without passing OpenJFX8 source `-PopenjdkPath` in Gradle. Both cases work.

