### PR TITLE
Update windows build toolchain to vs2013

### DIFF
--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -8,7 +8,9 @@ this project, you need to provide the following parameters:
 ```$xslt
 bootjdk_dir         # Path of bootstrap JDK. To build Corretto8, JDK7 or JDK8 is required.
 
-vcruntime_dir       # Path of the latest vcruntime100.dll
+vcruntime_dir       # Path of the latest msvcr120.dll
+
+msvcp_dir           # Path of the latest msvcp120.dll
 
 freetype_dir        # Path of freetype
 ```
@@ -20,6 +22,7 @@ The zip archives of Corretto8 JDK and JRE are located at `/installers/windows/zi
 ➜ ./gradlew :installers:windows:zip:build \
             -Pbootjdk_dir=... \
             -Pvcruntime_dir=... \
+            -Pmsvcp_dir=... \
             -Pfreetype_dir=...
 ```
 

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -35,8 +35,10 @@ task configureBuild(type: Exec) {
     // Platform specific flags
     def command = ['bash', 'configure',
             "--with-boot-jdk=${project.getProperty('bootjdk_dir')}",
-            "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/msvcr100.dll",
-            "--with-freetype=${project.getProperty('freetype_dir')}"]
+            "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/msvcr120.dll",
+            "--with-msvcp-dll=${project.getProperty('msvcp_dir')}/msvcp120.dll",
+            "--with-freetype=${project.getProperty('freetype_dir')}",
+            "--with-toolchain-version=2013"]
     // Common flags
     command += project.correttoCommonFlags
     commandLine command.flatten()


### PR DESCRIPTION
Reviewed-by: James Guo

Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description


### Related issues


### Motivation and context


### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
