### PR TITLE
Update gradle logic to only include Alpine when not on AArch64

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -12,8 +12,10 @@ if (Os.isFamily(Os.FAMILY_MAC)) {
                     ':installers:linux:universal:tar',
                     ':installers:linux:universal:rpm',
                     ':installers:linux:universal:deb',
-                    ':installers:linux:universal:test',
-                    ':installers:linux:alpine:tar']
+                    ':installers:linux:universal:test']
+    if (!Os.isArch("aarch64")) {
+        subProjects += [':installers:linux:alpine:tar']
+    }
 } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     subProjects += [':installers:windows:zip']
 }


### PR DESCRIPTION
Fixing build break on AArch64. Alpine project should not be included on aarch64 since it throws an exception when loading on this platform.