### PR TITLE
Allow setting the milestone as corretto.milestone at build time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,11 +65,12 @@ allprojects {
         jreTools = ['java', 'jjs', 'keytool', 'orbd', 'pack200', 'policytool', 'rmid', 'rmiregistry',
                     'servertool', 'tnameserv', 'unpack200']
 
+        def milestone = project.findProperty("corretto.milestone") ?: "fcs"
         correttoCommonFlags = [
                 "--with-update-version=${project.version.update}",
                 "--with-build-number=b${project.version.build}",
                 "--with-corretto-revision=${project.version.revision}",
-                '--with-milestone=fcs',
+                "--with-milestone=${milestone}",
                 '--enable-jfr',
                 '--with-vendor-name=Amazon.com Inc.',
                 '--with-vendor-url=https://aws.amazon.com/corretto/',


### PR DESCRIPTION
This value will get appended to the java version, not setting it will keep current behavior.

Example:
```
openjdk version "1.8.0_275-<milestone-name>"
OpenJDK Runtime Environment Corretto-8.275.01.1 (build 1.8.0_275-<milestone-name>)
OpenJDK 64-Bit Server VM Corretto-8.275.01.1 (build 25.275-b01, mixed mode)
```
