### PR TITLE
Replace Oracle bug report URL by a Corretto URL when VM crashes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,16 +9,9 @@ assignees: ''
 
 Thank you for taking the time to help improve OpenJDK and Corretto.
 
-If your request concerns a security vulnerability then please report it by email to aws-security@amazon.com instead of here.
-(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)
+If your request concerns a security vulnerability then please report it by email to aws-security@amazon.com instead of here. (You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)
 
-Otherwise, if your issue concerns OpenJDK 8
-and is not specific to Corretto 8
-we ask that you raise it to the OpenJDK community.
-Depending on your contributor status for OpenJDK,
-please use the [JDK bug system]() or
-the appropriate [mailing list](http://mail.openjdk.java.net/mailman/listinfo)
-for the given problem area or update project [jdk8u-dev](http://mail.openjdk.java.net/mailman/listinfo/jdk8u-dev).
+Otherwise, if your issue concerns OpenJDK 8 and is not specific to Corretto 8 we ask that you raise it to the OpenJDK community. Depending on your contributor status for OpenJDK, please use the [JDK bug system]() or the appropriate [mailing list](http://mail.openjdk.java.net/mailman/listinfo) for the given problem area or update project [jdk8u-dev](http://mail.openjdk.java.net/mailman/listinfo/jdk8u-dev).
 
 If your issue is specific to Corretto 8,
 then you are in the right place.
@@ -42,3 +35,5 @@ If applicable, add screenshots to help explain your problem.
 
 ### Additional context
 Add any other context about the problem here.
+
+For VM crashes, please attach the error report file. By default the file name is `hs_err_pidpid.log`, where pid is the process ID of the process.

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,8 @@ allprojects {
                 '--enable-jfr',
                 '--with-vendor-name=Amazon.com Inc.',
                 '--with-vendor-url=https://aws.amazon.com/corretto/',
-                "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/"
+                "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
+                "--with-vendor-vm-bug-url=https://github.com/corretto/corretto-${version.major}/issues/"
         ]
         is_x86 = false
         if (project.hasProperty("x86")) {


### PR DESCRIPTION

### Description
1. Replace the Oracle bug report URL of `http://bugreport.java.com/bugreport/crash.jsp` printed when VM crashes with Corretto issued URL.

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007fffd8ab2db7, pid=13641, tid=13642
#
# ...
#
# An error report file with more information is saved as:
# /share/software/Java/hs_err_pid13641.log
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
#
Aborted
```


2. Update Github issue template for bug report.
 
### How has this been tested?
- Build in local workspace

### Platform information
    Works on OS: All platforms
 