### PR TITLE
Fix crash due to bad shift in indirect addressing mode on aarch64 (fixes #302)

### DIFF
--- a/src/hotspot/src/cpu/aarch64/vm/aarch64.ad
+++ b/src/hotspot/src/cpu/aarch64/vm/aarch64.ad
@@ -926,6 +926,8 @@ definitions %{
 
 source_hpp %{
 
+#include "opto/addnode.hpp"
+
 class CallStubImpl {
  
   //--------------------------------------------------------------
@@ -980,6 +982,9 @@ class HandlerImpl {
 
   // predicate controlling translation of StoreCM
   bool unnecessary_storestore(const Node *storecm);
+
+  // predicate controlling addressing modes
+  bool size_fits_all_mem_uses(AddPNode* addp, int shift);
 %}
 
 source %{
@@ -2159,6 +2164,19 @@ const RegMask Matcher::method_handle_invoke_SP_save_mask() {
   return FP_REG_mask();
 }
 
+bool size_fits_all_mem_uses(AddPNode* addp, int shift) {
+  for (DUIterator_Fast imax, i = addp->fast_outs(imax); i < imax; i++) {
+    Node* u = addp->fast_out(i);
+    if (u->is_Mem()) {
+      int opsize = u->as_Mem()->memory_size();
+      assert(opsize > 0, "unexpected memory operand size");
+      if (u->as_Mem()->memory_size() != (1<<shift)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
 
 #define MOV_VOLATILE(REG, BASE, INDEX, SCALE, DISP, SCRATCH, INSN)	\
   MacroAssembler _masm(&cbuf);						\
@@ -4755,6 +4773,8 @@ operand indirect(iRegP reg)
 
 operand indIndexScaledOffsetI(iRegP reg, iRegL lreg, immIScale scale, immIU12 off)
 %{
+  predicate(size_fits_all_mem_uses(n->as_AddP(),
+                                   n->in(AddPNode::Address)->in(AddPNode::Offset)->in(2)->get_int()));
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (AddP reg (LShiftL lreg scale)) off);
   op_cost(INSN_COST);
@@ -4769,6 +4789,8 @@ operand indIndexScaledOffsetI(iRegP reg, iRegL lreg, immIScale scale, immIU12 of
 
 operand indIndexScaledOffsetL(iRegP reg, iRegL lreg, immIScale scale, immLU12 off)
 %{
+  predicate(size_fits_all_mem_uses(n->as_AddP(),
+                                   n->in(AddPNode::Address)->in(AddPNode::Offset)->in(2)->get_int()));
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (AddP reg (LShiftL lreg scale)) off);
   op_cost(INSN_COST);
@@ -4797,6 +4819,8 @@ operand indIndexOffsetI2L(iRegP reg, iRegI ireg, immLU12 off)
 
 operand indIndexScaledOffsetI2L(iRegP reg, iRegI ireg, immIScale scale, immLU12 off)
 %{
+  predicate(size_fits_all_mem_uses(n->as_AddP(),
+                                   n->in(AddPNode::Address)->in(AddPNode::Offset)->in(2)->get_int()));
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (AddP reg (LShiftL (ConvI2L ireg) scale)) off);
   op_cost(INSN_COST);
@@ -4811,6 +4835,8 @@ operand indIndexScaledOffsetI2L(iRegP reg, iRegI ireg, immIScale scale, immLU12 
 
 operand indIndexScaledI2L(iRegP reg, iRegI ireg, immIScale scale)
 %{
+  predicate(size_fits_all_mem_uses(n->as_AddP(),
+                                   n->in(AddPNode::Offset)->in(2)->get_int()));
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP reg (LShiftL (ConvI2L ireg) scale));
   op_cost(0);
@@ -4825,6 +4851,8 @@ operand indIndexScaledI2L(iRegP reg, iRegI ireg, immIScale scale)
 
 operand indIndexScaled(iRegP reg, iRegL lreg, immIScale scale)
 %{
+  predicate(size_fits_all_mem_uses(n->as_AddP(),
+                                   n->in(AddPNode::Offset)->in(2)->get_int()));
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP reg (LShiftL lreg scale));
   op_cost(0);
@@ -4980,7 +5008,9 @@ operand indirectN(iRegN reg)
 
 operand indIndexScaledOffsetIN(iRegN reg, iRegL lreg, immIScale scale, immIU12 off)
 %{
-  predicate(Universe::narrow_oop_shift() == 0);
+  predicate(Universe::narrow_oop_shift() == 0 &&
+            size_fits_all_mem_uses(n->as_AddP(),
+                                   n->in(AddPNode::Address)->in(AddPNode::Offset)->in(2)->get_int()));
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (AddP (DecodeN reg) (LShiftL lreg scale)) off);
   op_cost(0);
@@ -4995,7 +5025,9 @@ operand indIndexScaledOffsetIN(iRegN reg, iRegL lreg, immIScale scale, immIU12 o
 
 operand indIndexScaledOffsetLN(iRegN reg, iRegL lreg, immIScale scale, immLU12 off)
 %{
-  predicate(Universe::narrow_oop_shift() == 0);
+  predicate(Universe::narrow_oop_shift() == 0 &&
+            size_fits_all_mem_uses(n->as_AddP(),
+                                   n->in(AddPNode::Address)->in(AddPNode::Offset)->in(2)->get_int()));
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (AddP (DecodeN reg) (LShiftL lreg scale)) off);
   op_cost(INSN_COST);
@@ -5025,7 +5057,9 @@ operand indIndexOffsetI2LN(iRegN reg, iRegI ireg, immLU12 off)
 
 operand indIndexScaledOffsetI2LN(iRegN reg, iRegI ireg, immIScale scale, immLU12 off)
 %{
-  predicate(Universe::narrow_oop_shift() == 0);
+  predicate(Universe::narrow_oop_shift() == 0 &&
+            size_fits_all_mem_uses(n->as_AddP(),
+                                   n->in(AddPNode::Address)->in(AddPNode::Offset)->in(2)->get_int()));
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (AddP (DecodeN reg) (LShiftL (ConvI2L ireg) scale)) off);
   op_cost(INSN_COST);
@@ -5040,7 +5074,9 @@ operand indIndexScaledOffsetI2LN(iRegN reg, iRegI ireg, immIScale scale, immLU12
 
 operand indIndexScaledI2LN(iRegN reg, iRegI ireg, immIScale scale)
 %{
-  predicate(Universe::narrow_oop_shift() == 0);
+  predicate(Universe::narrow_oop_shift() == 0 &&
+            size_fits_all_mem_uses(n->as_AddP(),
+                                   n->in(AddPNode::Offset)->in(2)->get_int()));
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) (LShiftL (ConvI2L ireg) scale));
   op_cost(0);
@@ -5055,7 +5091,9 @@ operand indIndexScaledI2LN(iRegN reg, iRegI ireg, immIScale scale)
 
 operand indIndexScaledN(iRegN reg, iRegL lreg, immIScale scale)
 %{
-  predicate(Universe::narrow_oop_shift() == 0);
+  predicate(Universe::narrow_oop_shift() == 0 &&
+            size_fits_all_mem_uses(n->as_AddP(),
+                                   n->in(AddPNode::Offset)->in(2)->get_int()));
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP (DecodeN reg) (LShiftL lreg scale));
   op_cost(0);


### PR DESCRIPTION
This is fix for #302. The problem is that on aarch64, indirect loads and stores can accept and index and a shift, but the shift has to correspond to the size of the load/store operation (e.g. shift==2 for 32-bit operations and shift==3 for 64-bit operations). Usage of `sun.misc.Unsafe` can lead to address expressions which violate this requirement. They might for example request a shift of "1" for a 32-bit operation. In the release build, the generated code will nevertheless perform a 2-bit shift in such a situation which can lead to arbitrary crashes at a later time. In a debug build, the problem will be detected by the following assertion:
```
assert(_ext.shift() == (int)size) failed: bad shift
```

Notice that this issue was resolved by a larger change in jdk9 ([JDK-8154826: AArch64: take better advantage of base + shifted offset addressing mode](https://bugs.openjdk.java.net/browse/JDK-8154826)) which completely reworked complex addressing modes.

This change only fixes the current issue in jdk8 by checking the shift amount against the size of the memory operation in the Matcher and rejects address modes where they don't conform.