### PR TITLE
Update build logic to support command line tools for xcode

### DIFF
--- a/src/common/autoconf/generated-configure.sh
+++ b/src/common/autoconf/generated-configure.sh
@@ -4991,7 +4991,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1622754322
+DATE_WHEN_GENERATED=1623266407
 
 ###############################################################################
 #
@@ -27009,11 +27009,17 @@ fi
     XCODE_VERSION_OUTPUT=`xcodebuild -version 2>&1 | $HEAD -n 1`
     $ECHO "$XCODE_VERSION_OUTPUT" | $GREP "Xcode " > /dev/null
     if test $? -ne 0; then
-      as_fn_error $? "Failed to determine Xcode version." "$LINENO" 5
+      # xcodebuild is not available if command line tools are installed;
+      # fall back to testing the command line tools version with pkgutil
+      XCODE_VERSION_OUTPUT=`pkgutil --pkg-info=com.apple.pkg.CLTools_Executables 2>&1 | $GREP "version: "`
+      XCODE_MAJOR_VERSION=`$ECHO $XCODE_VERSION_OUTPUT | \
+          $SED -e 's/^version: \([1-9][0-9.]*\).*/\1/' | \
+          $CUT -f 1 -d .`
+    else
+      XCODE_MAJOR_VERSION=`$ECHO $XCODE_VERSION_OUTPUT | \
+          $SED -e 's/^Xcode \([1-9][0-9.]*\)/\1/' | \
+          $CUT -f 1 -d .`
     fi
-    XCODE_MAJOR_VERSION=`$ECHO $XCODE_VERSION_OUTPUT | \
-        $SED -e 's/^Xcode \([1-9][0-9.]*\)/\1/' | \
-        $CUT -f 1 -d .`
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Xcode major version: $XCODE_MAJOR_VERSION" >&5
 printf "%s\n" "$as_me: Xcode major version: $XCODE_MAJOR_VERSION" >&6;}
     if test $XCODE_MAJOR_VERSION -ge 5; then
@@ -28499,9 +28505,7 @@ fi
     fi
 
     # Fail-fast: verify we're building on a supported Xcode version
-    XCODE_VERSION=`$XCODEBUILD -version | grep '^Xcode ' | sed 's/Xcode //'`
-    XC_VERSION_PARTS=( ${XCODE_VERSION//./ } )
-    if test "${XC_VERSION_PARTS[0]}" != "6" -a "${XC_VERSION_PARTS[0]}" != "9" -a "${XC_VERSION_PARTS[0]}" != "10" -a "${XC_VERSION_PARTS[0]}" != "11" -a "${XC_VERSION_PARTS[0]}" != "12" ; then
+    if test "${XCODE_MAJOR_VERSION}" != "6" -a "${XCODE_MAJOR_VERSION}" != "9" -a "${XCODE_MAJOR_VERSION}" != "10" -a "${XCODE_MAJOR_VERSION}" != "11" -a "${XCODE_MAJOR_VERSION}" != "12" ; then
       as_fn_error $? "Xcode 6, 9-12 is required to build JDK 8, the version found was $XCODE_VERSION. Use --with-xcode-path to specify the location of Xcode or make Xcode active by using xcode-select." "$LINENO" 5
     fi
 
@@ -28525,8 +28529,14 @@ printf %s "checking Determining Xcode SDK path... " >&6; }
       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $SDKPATH" >&5
 printf "%s\n" "$SDKPATH" >&6; }
     else
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: (none, will use system headers and frameworks)" >&5
+      SDKPATH=`xcrun --show-sdk-path`
+      if  test -n "$SDKPATH"; then
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $SDKPATH" >&5
+printf "%s\n" "$SDKPATH" >&6; }
+      else
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: (none, will use system headers and frameworks)" >&5
 printf "%s\n" "(none, will use system headers and frameworks)" >&6; }
+      fi
     fi
 
 

--- a/src/common/autoconf/toolchain.m4
+++ b/src/common/autoconf/toolchain.m4
@@ -155,11 +155,17 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
     XCODE_VERSION_OUTPUT=`xcodebuild -version 2>&1 | $HEAD -n 1`
     $ECHO "$XCODE_VERSION_OUTPUT" | $GREP "Xcode " > /dev/null
     if test $? -ne 0; then
-      AC_MSG_ERROR([Failed to determine Xcode version.])
+      # xcodebuild is not available if command line tools are installed;
+      # fall back to testing the command line tools version with pkgutil
+      XCODE_VERSION_OUTPUT=`pkgutil --pkg-info=com.apple.pkg.CLTools_Executables 2>&1 | $GREP "version: "`
+      XCODE_MAJOR_VERSION=`$ECHO $XCODE_VERSION_OUTPUT | \
+          $SED -e 's/^version: \(@<:@1-9@:>@@<:@0-9.@:>@*\).*/\1/' | \
+          $CUT -f 1 -d .`
+    else
+      XCODE_MAJOR_VERSION=`$ECHO $XCODE_VERSION_OUTPUT | \
+          $SED -e 's/^Xcode \(@<:@1-9@:>@@<:@0-9.@:>@*\)/\1/' | \
+          $CUT -f 1 -d .`
     fi
-    XCODE_MAJOR_VERSION=`$ECHO $XCODE_VERSION_OUTPUT | \
-        $SED -e 's/^Xcode \(@<:@1-9@:>@@<:@0-9.@:>@*\)/\1/' | \
-        $CUT -f 1 -d .`
     AC_MSG_NOTICE([Xcode major version: $XCODE_MAJOR_VERSION])
     if test $XCODE_MAJOR_VERSION -ge 5; then
         DEFAULT_TOOLCHAIN="clang"
@@ -288,9 +294,7 @@ AC_DEFUN_ONCE([TOOLCHAIN_PRE_DETECTION],
     fi
 
     # Fail-fast: verify we're building on a supported Xcode version
-    XCODE_VERSION=`$XCODEBUILD -version | grep '^Xcode ' | sed 's/Xcode //'`
-    XC_VERSION_PARTS=( ${XCODE_VERSION//./ } )
-    if test "${XC_VERSION_PARTS[[0]]}" != "6" -a "${XC_VERSION_PARTS[[0]]}" != "9" -a "${XC_VERSION_PARTS[[0]]}" != "10" -a "${XC_VERSION_PARTS[[0]]}" != "11" -a "${XC_VERSION_PARTS[[0]]}" != "12" ; then
+    if test "${XCODE_MAJOR_VERSION}" != "6" -a "${XCODE_MAJOR_VERSION}" != "9" -a "${XCODE_MAJOR_VERSION}" != "10" -a "${XCODE_MAJOR_VERSION}" != "11" -a "${XCODE_MAJOR_VERSION}" != "12" ; then
       AC_MSG_ERROR([Xcode 6, 9-12 is required to build JDK 8, the version found was $XCODE_VERSION. Use --with-xcode-path to specify the location of Xcode or make Xcode active by using xcode-select.])
     fi
 
@@ -311,7 +315,12 @@ AC_DEFUN_ONCE([TOOLCHAIN_PRE_DETECTION],
     if test -n "$SDKPATH"; then
       AC_MSG_RESULT([$SDKPATH])
     else
-      AC_MSG_RESULT([(none, will use system headers and frameworks)])
+      SDKPATH=`xcrun --show-sdk-path`
+      if  test -n "$SDKPATH"; then
+        AC_MSG_RESULT([$SDKPATH])
+      else
+        AC_MSG_RESULT([(none, will use system headers and frameworks)])
+      fi
     fi
     AC_SUBST(SDKPATH)
 


### PR DESCRIPTION
The existing build logic for xcode relies heavily on xcodebuild, which is fully functional only when a full xcode install is present. However the command line tools alone are sufficient to build.

This patch updates the build logic to fall back to command line tools only equivalents when a full xcode / xcodebuild is not available.