### PR TITLE
Add javafx build logic patch for command line tools

### DIFF
--- a/javafx/patches/mac os x/0001-8232158-macOS-Fallback-to-command-line-tools-if-xcod.patch
+++ b/javafx/patches/mac os x/0001-8232158-macOS-Fallback-to-command-line-tools-if-xcod.patch
@@ -1,0 +1,87 @@
+From ab6ea3b936f319cdea997aabed63ffdc639a75e1 Mon Sep 17 00:00:00 2001
+From: Arunprasad Rajkumar <arajkumar@openjdk.org>
+Date: Wed, 23 Oct 2019 08:41:40 +0000
+Subject: [PATCH] 8232158: [macOS] Fallback to command line tools if xcode is
+ missing
+
+Reviewed-by: kcr, jvos
+---
+ buildSrc/mac.gradle | 50 +++++++++++++++++++++++++++++----------------
+ 1 file changed, 32 insertions(+), 18 deletions(-)
+
+diff --git a/buildSrc/mac.gradle b/buildSrc/mac.gradle
+index cb8ec45181..539fad1ead 100644
+--- a/buildSrc/mac.gradle
++++ b/buildSrc/mac.gradle
+@@ -61,28 +61,37 @@ setupTools("mac_tools",
+         } else if (!file(defaultSdkPath).isDirectory()) {
+             // Get list of all macosx sdks
+             ByteArrayOutputStream results = new ByteArrayOutputStream();
+-            exec {
++            def xcodeBuildResult = exec {
+                 commandLine("xcodebuild", "-version", "-showsdks");
+                 setStandardOutput(results);
++                ignoreExitValue(true);
+             }
+-
+-            BufferedReader reader = new BufferedReader(new StringReader(results.toString().trim()));
+-            // If our preferred SDK is in the list use it, else use the default
+-            String sdk = "macosx"
+-            String prefSdk = sdk + prefSdkVersion
+-            while (true) {
+-                def line = reader.readLine();
+-                if (line == null) break;
+-                if (line.contains("-sdk ${prefSdk}")) {
+-                    sdk = prefSdk
+-                    break;
++            if (xcodeBuildResult.exitValue == 0) {
++                BufferedReader reader = new BufferedReader(new StringReader(results.toString().trim()));
++                // If our preferred SDK is in the list use it, else use the default
++                String sdk = "macosx"
++                String prefSdk = sdk + prefSdkVersion
++                while (true) {
++                    def line = reader.readLine();
++                    if (line == null) break;
++                    if (line.contains("-sdk ${prefSdk}")) {
++                        sdk = prefSdk
++                        break;
++                    }
+                 }
+-            }
+ 
+-            results = new ByteArrayOutputStream();
+-            exec {
+-                commandLine("xcodebuild", "-version", "-sdk", sdk, "Path");
+-                setStandardOutput(results);
++                results = new ByteArrayOutputStream();
++                exec {
++                    commandLine("xcodebuild", "-version", "-sdk", sdk, "Path");
++                    setStandardOutput(results);
++                }
++            } else {
++                // try with command line developer tools
++                results = new ByteArrayOutputStream();
++                exec {
++                    commandLine("xcrun", "--show-sdk-path");
++                    setStandardOutput(results);
++                }
+             }
+             String sdkPath = results.toString().trim();
+             propFile << "MACOSX_SDK_PATH=" << sdkPath << "\n";
+@@ -97,7 +106,12 @@ println "MACOSX_MIN_VERSION = $MACOSX_MIN_VERSION"
+ println "MACOSX_SDK_PATH = $MACOSX_SDK_PATH"
+ 
+ if (!file(MACOSX_SDK_PATH).isDirectory()) {
+-    throw new GradleException("FAIL: Cannot find $MACOSX_SDK_PATH")
++    throw new GradleException(
++        """
++        FAIL: Cannot find $MACOSX_SDK_PATH
++        Install Xcode or Command line developer tool using `xcode-select --install`
++        """
++    );
+ }
+ 
+ // NOTE: There is no space between -iframework and the specified path
+-- 
+2.32.0
+


### PR DESCRIPTION
This allows jfx to build with a command line tools install instead of a full xcode install
Patch generated from https://github.com/openjdk/jfx/commit/ab6ea3b936f319cdea997aabed63ffdc639a75e1