### PR TITLE
Allow passing freetype path as a corretto option; if present, fix up …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,14 @@ allprojects {
                 throw new RuntimeException("Invalid corretto.debug_level")
         }
 
+        def freetypeIncludePath = project.findProperty("corretto.freetype_include")
+        def freetypeLibPath = project.findProperty("corretto.freetype_lib")
+
+        // If freetype location is specified, pass to configure
+        if (freetypeIncludePath && freetypeLibPath) {
+            correttoCommonFlags += ["--with-freetype-include=${freetypeIncludePath}", "--with-freetype-lib=${freetypeLibPath}"]
+        }
+
         // customized flags. Identify the index of double dashes as the start of a flag
         String extraConfig = project.findProperty("corretto.extra_config")
         def lastIndex = -1

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -149,6 +149,17 @@ task prepareArtifacts {
             workingDir "${buildDir}/${correttoMacDir}/Contents"
             commandLine "ln", "-sf", "../Home/jre/lib/jli/libjli.dylib", "MacOS/libjli.dylib"
         }
+
+        // Fix freetype linking and permissions
+        def freetypeLibPath = project.findProperty("corretto.freetype_lib")
+        if (freetypeLibPath) {
+            exec {
+                workingDir "${buildDir}/${correttoMacDir}/Contents/Home"
+                commandLine "chmod", "755", "./jre/lib/libfreetype.dylib.6"
+                commandLine "install_name_tool", "-change", "${freetypeLibPath}/libfreetype.6.dylib", "@rpath/libfreetype.dylib.6", "./jre/lib/libfontmanager.dylib"
+                commandLine "install_name_tool", "-id", "@rpath/libfreetype.dylib.6", "./jre/lib/libfreetype.dylib.6"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
…libfreetype.dylib.6 on macos

Tested with brew installed freetype with
`./gradlew :installers:mac:tar:build -Pcorretto.freetype_include=/usr/local/opt/freetype/include/freetype2 -Pcorretto.freetype_lib=/usr/local/opt/freetype/lib`

