### PR TITLE
Fix LinuxThreads detection in MUSL

### DIFF
--- a/src/jdk/src/solaris/native/sun/tools/attach/LinuxVirtualMachine.c
+++ b/src/jdk/src/solaris/native/sun/tools/attach/LinuxVirtualMachine.c
@@ -195,6 +195,9 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_LinuxVirtualMachine_connect
 JNIEXPORT jboolean JNICALL Java_sun_tools_attach_LinuxVirtualMachine_isLinuxThreads
   (JNIEnv *env, jclass cls)
 {
+# ifdef MUSL_LIBC
+   return JNI_FALSE;
+# else
 # ifndef _CS_GNU_LIBPTHREAD_VERSION
 # define _CS_GNU_LIBPTHREAD_VERSION 3
 # endif
@@ -222,6 +225,7 @@ JNIEXPORT jboolean JNICALL Java_sun_tools_attach_LinuxVirtualMachine_isLinuxThre
     res = (jboolean)(strstr(s, "NPTL") == NULL);
     free(s);
     return res;
+# endif
 }
 
 /*


### PR DESCRIPTION
`isLinuxThreads` function identified MUSL builds to use LinuxThreads. This causes issues with commands such as `jcmd` etc when the java process is running with pid 1 within containers. 

