### PR TITLE
Fix version numbers in .pkg metadata and Info.plist

### DIFF
--- a/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
+++ b/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
@@ -164,7 +164,7 @@
         <key>USE_HFS+_COMPRESSION</key>
         <false/>
         <key>VERSION</key>
-        <string>1.0</string>
+        <string>@full@</string>
       </dict>
       <key>TYPE</key>
       <integer>0</integer>

--- a/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
+++ b/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
@@ -45,7 +45,7 @@
                           <key>GID</key>
                           <integer>0</integer>
                           <key>PATH</key>
-                          <string>amazon-corretto-8.jdk</string>
+                          <string>amazon-corretto-@major@.jdk</string>
                           <key>PATH_TYPE</key>
                           <integer>1</integer>
                           <key>PERMISSIONS</key>
@@ -148,11 +148,11 @@
         <key>FOLLOW_SYMBOLIC_LINKS</key>
         <false/>
         <key>IDENTIFIER</key>
-        <string>com.amazon.corretto.8</string>
+        <string>com.amazon.corretto.@major@</string>
         <key>LOCATION</key>
         <integer>0</integer>
         <key>NAME</key>
-        <string>amazon-corretto-8.jdk</string>
+        <string>amazon-corretto-@major@.jdk</string>
         <key>OVERWRITE_PERMISSIONS</key>
         <false/>
         <key>PAYLOAD_SIZE</key>
@@ -363,7 +363,7 @@
             <key>LANGUAGE</key>
             <string>English</string>
             <key>VALUE</key>
-            <string>Amazon Corretto 8</string>
+            <string>Amazon Corretto @major@</string>
           </dict>
         </array>
       </dict>

--- a/installers/mac/tar/templates/Info.plist.template
+++ b/installers/mac/tar/templates/Info.plist.template
@@ -9,11 +9,11 @@
         <key>CFBundleGetInfoString</key>
         <string>Amazon Corretto @full@</string>
         <key>CFBundleIdentifier</key>
-        <string>com.amazon.corretto.8</string>
+        <string>com.amazon.corretto.@major@</string>
         <key>CFBundleInfoDictionaryVersion</key>
         <string>7.0</string>
         <key>CFBundleName</key>
-        <string>Amazon Corretto 8</string>
+        <string>Amazon Corretto @major@</string>
         <key>CFBundlePackageType</key>
         <string>BNDL</string>
         <key>CFBundleShortVersionString</key>

--- a/installers/mac/tar/templates/Info.plist.template
+++ b/installers/mac/tar/templates/Info.plist.template
@@ -17,7 +17,7 @@
         <key>CFBundlePackageType</key>
         <string>BNDL</string>
         <key>CFBundleShortVersionString</key>
-        <string>1.0</string>
+        <string>@major@.@update@.@build@</string>
         <key>CFBundleSignature</key>
         <string>????</string>
         <key>CFBundleVersion</key>


### PR DESCRIPTION
This PR brings Corretto 8 into parity with 11+ by backporting [corretto-11#68](https://github.com/corretto/corretto-11/pull/68) and [corretto-11#69](https://github.com/corretto/corretto-11/pull/69)