### PR TITLE
Add support for XCode 13 in toolchain.m4

### DIFF
--- a/src/common/autoconf/generated-configure.sh
+++ b/src/common/autoconf/generated-configure.sh
@@ -4417,7 +4417,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1624896904
+DATE_WHEN_GENERATED=1633391466
 
 ###############################################################################
 #
@@ -20032,7 +20032,6 @@ fi
 
 
 
-
   # The vendor name, if any
 
 # Check whether --with-vendor-name was given.
@@ -26949,8 +26948,8 @@ fi
     fi
 
     # Fail-fast: verify we're building on a supported Xcode version
-    if test "${XCODE_MAJOR_VERSION}" != "6" -a "${XCODE_MAJOR_VERSION}" != "9" -a "${XCODE_MAJOR_VERSION}" != "10" -a "${XCODE_MAJOR_VERSION}" != "11" -a "${XCODE_MAJOR_VERSION}" != "12" ; then
-      as_fn_error $? "Xcode 6, 9-12 is required to build JDK 8, the version found was $XCODE_VERSION. Use --with-xcode-path to specify the location of Xcode or make Xcode active by using xcode-select." "$LINENO" 5
+    if test "${XCODE_MAJOR_VERSION}" != "6" -o "${XCODE_MAJOR_VERSION}" < "9" ; then
+      as_fn_error $? "Xcode 6, or 9+ is required to build JDK 8, the version found was $XCODE_VERSION. Use --with-xcode-path to specify the location of Xcode or make Xcode active by using xcode-select." "$LINENO" 5
     fi
 
     # Some versions of Xcode command line tools install gcc and g++ as symlinks to

--- a/src/common/autoconf/toolchain.m4
+++ b/src/common/autoconf/toolchain.m4
@@ -294,8 +294,8 @@ AC_DEFUN_ONCE([TOOLCHAIN_PRE_DETECTION],
     fi
 
     # Fail-fast: verify we're building on a supported Xcode version
-    if test "${XCODE_MAJOR_VERSION}" != "6" -a "${XCODE_MAJOR_VERSION}" != "9" -a "${XCODE_MAJOR_VERSION}" != "10" -a "${XCODE_MAJOR_VERSION}" != "11" -a "${XCODE_MAJOR_VERSION}" != "12" ; then
-      AC_MSG_ERROR([Xcode 6, 9-12 is required to build JDK 8, the version found was $XCODE_VERSION. Use --with-xcode-path to specify the location of Xcode or make Xcode active by using xcode-select.])
+    if test "${XCODE_MAJOR_VERSION}" != "6" -o "${XCODE_MAJOR_VERSION}" < "9" ; then
+      AC_MSG_ERROR([Xcode 6, or 9+ is required to build JDK 8, the version found was $XCODE_VERSION. Use --with-xcode-path to specify the location of Xcode or make Xcode active by using xcode-select.])
     fi
 
     # Some versions of Xcode command line tools install gcc and g++ as symlinks to


### PR DESCRIPTION
### Description
Enables building with Xcode 13

### How has this been tested?
- Built on macos 11.6 with Xcode 13