### PR TITLE
8234916: [macos 10.15] Garbled text running with native-image

### DIFF
--- a/javafx/patches/shared/0007-8234916-macos-10.15-Garbled-text-running-with-native.patch
+++ b/javafx/patches/shared/0007-8234916-macos-10.15-Garbled-text-running-with-native.patch
@@ -1,0 +1,34 @@
+From 4ddf55428d06dddadfc8cd14baabdc4d17318ee2 Mon Sep 17 00:00:00 2001
+From: Jose Pereda <jpereda@openjdk.org>
+Date: Thu, 5 Dec 2019 20:13:53 +0000
+Subject: [PATCH] 8234916: [macos 10.15] Garbled text running with native-image
+
+Reviewed-by: prr
+---
+ .../graphics/src/main/native-font/coretext.c    | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/modules/graphics/src/main/native-font/coretext.c b/modules/graphics/src/main/native-font/coretext.c
+index d84ba0fc1d..f02c626532 100644
+--- a/modules/graphics/src/main/native-font/coretext.c
++++ b/modules/graphics/src/main/native-font/coretext.c
+@@ -388,7 +388,15 @@ JNIEXPORT jlong JNICALL OS_NATIVE(CTFontCreateWithName)
+     CGAffineTransform _arg2, *lparg2=NULL;
+     jlong rc = 0;
+     if (arg2) if ((lparg2 = getCGAffineTransformFields(env, arg2, &_arg2)) == NULL) goto fail;
+-    rc = (jlong)CTFontCreateWithName((CFStringRef)arg0, (CGFloat)arg1, (CGAffineTransform*)lparg2);
++    CFStringRef fontName = (CFStringRef)arg0;
++    if (CFStringGetCharacterAtIndex(fontName, 0) == '.') {
++        bool bold = CFStringFind(fontName, CFSTR("bold"), kCFCompareCaseInsensitive).location != kCFNotFound;
++        CTFontRef font = CTFontCreateUIFontForLanguage(bold ? kCTFontUIFontEmphasizedSystem : kCTFontUIFontSystem, 0.0, NULL);
++        rc = (jlong) CTFontCreateCopyWithAttributes(font, (CGFloat)arg1, (CGAffineTransform*)lparg2, NULL);
++        CFRelease(font);
++    } else {
++        rc = (jlong) CTFontCreateWithName(fontName, (CGFloat)arg1, (CGAffineTransform*)lparg2);
++    }
+ fail:
+     /* In only */
+ //    if (arg2 && lparg2) setCGAffineTransformFields(env, arg2, lparg2);
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
This is a request to backport the fix for [JDK-8234916](https://bugs.openjdk.java.net/browse/JDK-8234916) to the Corretto-8
it is needed to fix the "garbled text" in this issue: https://github.com/corretto/corretto-8/issues/333

The patch applies "cleanly", I have tested in Jenkins that the bug is reproduced before the fix, and is not reproduced after the fix.

The [Oracle 8u](https://bugs.openjdk.java.net/browse/JDK-8238627) already has this fix.

The mainline patch: https://github.com/openjdk/jfx/commit/4ddf5542
The review: https://mail.openjdk.java.net/pipermail/openjfx-dev/2019-November/024150.html