### PR TITLE
8275565: generate_d2i_wrapper() doesn't save XMM registers if _LP64 i…

### DIFF
--- a/src/hotspot/make/windows/makefiles/compile.make
+++ b/src/hotspot/make/windows/makefiles/compile.make
@@ -77,7 +77,7 @@ LP64=1
 !if "$(BUILDARCH)" == "i486"
 MACHINE=I386
 DEFAULT_COMPILER_NAME=VS2003
-CXX_FLAGS=$(CXX_FLAGS) /D "IA32"
+CXX_FLAGS=$(CXX_FLAGS) /D "IA32" /arch:IA32
 !endif
 
 # Sanity check, this is the default if not amd64, ia64, or i486


### PR DESCRIPTION
…s not defined

Corretto-8 surfaces this issue after we upgrade vs2013. This patch actually is a backport of
JDK-8077590 to jdk8u.
Discussion are here: https://mail.openjdk.java.net/pipermail/hotspot-dev/2015-April/018258.html

VS2013 generates code using XMM registers by default. As a result, it may accidentally clobber
XMM registers which store spilling values of GPRs. This patch uses '-arch:IA32' for windows x86 build.

The following message is from MSVC documentation.
/arch:IA32 Specifies no enhanced instructions and also specifies x87 for floating-point calculations.

Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
use MSVC flag -arch:IA32 to build jdk8u on windows x86. 

### Related issues
#305 
#331 

### Motivation and context
Corretto-8 uses C2 JIT compiler by default. C2 has a feature called UseFPUForSpilling which spills GPRs to XMM registers. generate_d2i_wrapper() doesn't save XMM0~7 on 32-bit system. As a result, runtime calls via generate_d2i_wrapper() may accidentally clobber XMM registers.  eg.  SharedRuntime::d2l uses XMM0 registers as a temporary register after we upgrade toolchain to vs2013. Adding option /arch:IA32 specifies x87 for floating-point calculations. It will avoid XMM registers from clobbering.

### How has this been tested?
I have manually verified that #331 is solved. 

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context
A discussion of the similar problem on hotspot-dev mailing list. 
https://mail.openjdk.java.net/pipermail/hotspot-dev/2015-April/018258.html

A JBS bug report with technical details.
https://bugs.openjdk.java.net/browse/JDK-8275565

### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
