### PR TITLE
Separate tar for zipped debug symbols in release build.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,6 @@ allprojects {
         switch(project.findProperty("corretto.debug_level")) {
             case null:
             case "release":
-                correttoCommonFlags += ['--disable-debug-symbols', '--disable-zip-debug-info']
                 break
             case "fastdebug":
                 correttoDebugLevel = "fastdebug"
@@ -173,7 +172,7 @@ allprojects {
             correttoJdkArchiveName =
                     "amazon-corretto-${project.version.full}-${os}-${correttoArch}-${correttoDebugLevel}".toString()
         }
-
+        correttoDebugSymbolsArchiveName = "amazon-corretto-debugsymbols-${project.version.full}-${os}-${correttoArch}".toString()
     }
 }
 

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -38,6 +38,7 @@ ext {
 def jdkResultingImage = "$buildRoot/src/build/linux-${arch}-normal-server-release/images/j2sdk-image"
 def binaryResultName = "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
 def archiveName = "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
+def debugArchiveName = "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
 
 /**
  * Create a local copy of the source tree in our
@@ -62,8 +63,6 @@ task configureBuild(type: Exec) {
             "--with-build-number=b${project.version.build}",
             "--with-corretto-revision=${project.version.revision}",
             "--with-milestone=${milestone}",
-            '--disable-debug-symbols',
-            '--disable-zip-debug-info',
             'LIBCXX=-static-libstdc++ -static-libgcc',
             '--with-vendor-name=Amazon.com Inc.',
             '--with-vendor-url=https://aws.amazon.com/corretto/',
@@ -114,12 +113,24 @@ task copyBuildResults() {
     }
 }
 
+task packageDebugSymbols(type: Exec) {
+    description 'Package the JDK debug symbols and puts the results in build/distributions.'
+    dependsOn copyBuildResults
+    String tarFile = "${distributionDir}/${debugArchiveName}"
+    outputs.file tarFile
+    workingDir buildDir
+    commandLine 'bash', '-c',
+        "tar -czf ${tarFile} ${binaryResultName}/**/*.diz"
+}
+
 task packageBuildResults(type: Exec) {
     description 'Package the JDK image and puts the results in build/distributions.'
-    dependsOn copyBuildResults
-    outputs.dir distributionDir
+    dependsOn packageDebugSymbols
+    String tarFile = "${distributionDir}/${archiveName}"
+    outputs.file tarFile
     workingDir buildDir
-    commandLine 'tar', 'cfz', "${distributionDir}/${archiveName}", binaryResultName
+    commandLine 'bash', '-c',
+        "tar --exclude=*.diz -czf ${tarFile} ${binaryResultName}"
 }
 
 artifacts {

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -124,12 +124,24 @@ task copyBuildResults() {
     }
 }
 
+task packageDebugSymbols(type: Exec) {
+    description 'Package the JDK debug symbols and puts the results in build/distributions.'
+    dependsOn copyBuildResults
+    String tarFile = "${distributionDir}/${project.correttoDebugSymbolsArchiveName}.tar.gz"
+    outputs.file tarFile
+    workingDir buildDir
+    commandLine 'bash', '-c',
+        "tar -czf ${tarFile} ${project.correttoJdkArchiveName}/**/*.diz"
+}
+
 task packageBuildResults(type: Exec) {
     description 'Package the JDK image and puts the results in build/distributions.'
-    dependsOn copyBuildResults
-    outputs.dir distributionDir
+    dependsOn packageDebugSymbols
+    String tarFile = "${distributionDir}/${project.correttoJdkArchiveName}.tar.gz"
+    outputs.file tarFile
     workingDir buildDir
-    commandLine 'tar', 'cfz', "${distributionDir}/${project.correttoJdkArchiveName}.tar.gz", project.correttoJdkArchiveName
+    commandLine 'bash', '-c',
+        "tar --exclude=*.diz -czf ${tarFile} ${project.correttoJdkArchiveName}"
 }
 
 artifacts {

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -169,11 +169,21 @@ task prepareArtifacts {
     }
 }
 
-task packaging(type: Exec) {
+task packageDebugSymbols(type: Exec) {
     dependsOn prepareArtifacts
+    String tarDir = "${distributionDir}/${project.correttoDebugSymbolsArchiveName}.tar.gz"
+    workingDir buildDir
+    commandLine 'bash', '-c',
+        "tar -czf ${tarDir} ${correttoMacDir}/Contents/Home/bin/*.diz"
+    outputs.file tarDir
+}
+
+task packaging(type: Exec) {
+    dependsOn packageDebugSymbols
     String tarDir = "${distributionDir}/${project.correttoJdkArchiveName}.tar.gz"
     workingDir buildDir
-    commandLine "tar", "czf", tarDir, correttoMacDir
+    commandLine 'bash', '-c',
+        "tar --exclude=*.diz -czf ${tarDir} ${correttoMacDir}"
     outputs.file tarDir
 }
 

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -97,11 +97,22 @@ task copyImage() {
     }
 }
 
-task packageJdk(type: Zip) {
+task packageDebugSymbols(type: Zip) {
     dependsOn copyImage
+    archiveName  = "unsigned-jdk-debugsymbols-image.${project.correttoArch}.zip"
+
+    from ("$buildRoot/build/j2sdk-image") {
+        include '**/*.diz'
+    }
+}
+
+task packageJdk(type: Zip) {
+    dependsOn packageDebugSymbols
     archiveName  = "unsigned-jdk-image.${project.correttoArch}.zip"
 
-    from "$buildRoot/build/j2sdk-image"
+    from("$buildRoot/build/j2sdk-image") {
+        exclude '**/*.diz'
+    }
 }
 
 task packageJre(type: Zip) {


### PR DESCRIPTION
Separate tar for zipped debug symbols in release build.


### How has this been tested?
Build on all platforms with the default `./gradlew`. Passes internal pipelines.


### Platform information
AL2, Alpine, Mac, Windows



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
