### PR TITLE
Alpine build uses correttoCommonFlags.

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -58,16 +58,14 @@ task configureBuild(type: Exec) {
     workingDir "$buildRoot/src"
 
     def milestone = project.findProperty("corretto.milestone") ?: "fcs"
-    commandLine 'bash', 'configure',
-            "--with-update-version=${project.version.update}",
-            "--with-build-number=b${project.version.build}",
-            "--with-corretto-revision=${project.version.revision}",
-            "--with-milestone=${milestone}",
-            'LIBCXX=-static-libstdc++ -static-libgcc',
-            '--with-vendor-name=Amazon.com Inc.',
-            '--with-vendor-url=https://aws.amazon.com/corretto/',
-            "--with-vendor-bug-url=https://github.com/corretto/corretto-${version.major}/issues/",
-            "--with-vendor-vm-bug-url=https://github.com/corretto/corretto-${version.major}/issues/"
+    def configureCmd = [
+        'bash',
+        'configure',
+        'LIBCXX=-static-libstdc++ -static-libgcc'
+    ]
+    configureCmd += correttoCommonFlags
+
+    commandLine configureCmd
 }
 
 task executeBuild(type: Exec) {


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Cleanup Alpine build scripts to use `correttoCommonFlags`. Making sure common flags are actually common to all platforms. Nothing is functionally different.

### Related issues
Corretto 11 equivalent PR: https://github.com/corretto/corretto-11/pull/248

### How has this been tested?
Tested locally and in Jenkins pipeline.

### Platform information
    Alpine



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
