### PR TITLE
Add all debug symbols recursively in the build root.

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -120,7 +120,7 @@ task packageDebugSymbols(type: Exec) {
     outputs.file tarFile
     workingDir buildDir
     commandLine 'bash', '-c',
-        "tar -czf ${tarFile} ${binaryResultName}/**/*.diz"
+        "tar -czf ${tarFile} \$(find ${binaryResultName} -name \"*.diz\")"
 }
 
 task packageBuildResults(type: Exec) {

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -131,7 +131,7 @@ task packageDebugSymbols(type: Exec) {
     outputs.file tarFile
     workingDir buildDir
     commandLine 'bash', '-c',
-        "tar -czf ${tarFile} ${project.correttoJdkArchiveName}/**/*.diz"
+        "tar -czf ${tarFile} \$(find ${project.correttoJdkArchiveName} -name \"*.diz\")"
 }
 
 task packageBuildResults(type: Exec) {

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -192,7 +192,7 @@ task packageDebugSymbols(type: Exec) {
     String tarDir = "${distributionDir}/${project.correttoDebugSymbolsArchiveName}.tar.gz"
     workingDir buildDir
     commandLine 'bash', '-c',
-        "tar -czf ${tarDir} ${correttoMacDir}/Contents/Home/bin/*.diz"
+        "tar -czf ${tarDir} \$(find ${correttoMacDir} -name \"*.diz\")"
     outputs.file tarDir
 }
 


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Fixes https://github.com/corretto/corretto-8/issues/356. Currently, we only package debug symbols in `bin/`. This change also packages debug symbols in `jre/**/`


### How has this been tested?
Testing on generic linux, Alpine, Mac. Verified debug symbols tars have *.diz files in jre directory


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
