### PR TITLE
Fix WX assertion failures in debug builds

### DIFF
--- a/src/hotspot/src/share/vm/runtime/thread.cpp
+++ b/src/hotspot/src/share/vm/runtime/thread.cpp
@@ -262,6 +262,7 @@ Thread::Thread() {
 
 #ifdef ASSERT
   _visited_for_critical_count = false;
+  _wx_init = false;
 #endif
 
   _SR_lock = new Monitor(Mutex::suspend_resume, "SR_lock", true);
@@ -954,8 +955,6 @@ void Thread::check_for_valid_safepoint_state(bool potential_vm_operation) {
       InterfaceSupport::check_gc_alot();
     }
 #endif
-
-  DEBUG_ONLY(_wx_init = false);
 }
 #endif
 


### PR DESCRIPTION
As described in https://github.com/corretto/corretto-8/issues/374, debug builds currently fail in an assertion related to W^X protection recently added to support the Mac M1 platform.

(Note - I don't understand all the details of the original backport, so this fix might not make sense, but at least this is a starting point for discussion).

The first issue was that _wx_init was not being initialized in the thread constructor, but the assertions rely on it starting as false and being set to true via init_wx().

After solving this, there was a new assertion failure:
```
#  Internal Error src/hotspot/src/share/vm/runtime/thread.hpp:679), pid=18557, tid=0x00007f1c471ec700
#  assert(current->_wx_init) failed: no init

V  [libjvm.so+0x11a68a1]  VMError::report_and_die()+0x2e1
V  [libjvm.so+0x76eb9f]  report_vm_error(char const*, int, char const*, char const*)+0x5f
V  [libjvm.so+0x66b1b8]  ClassLoader::create_class_path_entry(char const*, stat const*, bool, bool, Thread*)+0x668
V  [libjvm.so+0x66b5dc]  LazyClassPathEntry::resolve_entry(Thread*) [clone .part.68]+0x2c
V  [libjvm.so+0x66b79c]  LazyClassPathEntry::open_stream(char const*, Thread*)+0xcc
V  [libjvm.so+0x66e3de]  ClassLoader::load_classfile(Symbol*, Thread*)+0x19e
V  [libjvm.so+0x10d74a8]  SystemDictionary::load_instance_class(Symbol*, Handle, Thread*)+0x468
V  [libjvm.so+0x10d5607]  SystemDictionary::resolve_instance_class_or_null(Symbol*, Handle, Handle, Thread*)+0x997
V  [libjvm.so+0x10d5dd7]  SystemDictionary::resolve_or_null(Symbol*, Handle, Handle, Thread*)+0x187
V  [libjvm.so+0x10d78ea]  SystemDictionary::initialize_wk_klasses_until(SystemDictionary::WKID, SystemDictionary::WKID&, Thread*)+0x1ca
V  [libjvm.so+0x10d7a21]  SystemDictionary::initialize_preloaded_classes(Thread*)+0xb1
V  [libjvm.so+0x10d7ee5]  SystemDictionary::initialize(Thread*)+0x295
V  [libjvm.so+0x11468af]  Universe::genesis(Thread*)+0x8af
V  [libjvm.so+0x114725c]  universe2_init()+0x2c
V  [libjvm.so+0x99f9b7]  init_globals()+0xa7
V  [libjvm.so+0x1116f9c]  Threads::create_vm(JavaVMInitArgs*, bool*)+0x2ac
V  [libjvm.so+0xb578ad]  JNI_CreateJavaVM+0x5d
C  [libjli.so+0x5f10]  JavaMain+0x90
C  [libpthread.so.0+0x744b]  start_thread+0xdb
```

This was because _wx_init is reset to false in `Thread::check_for_valid_safepoint_state`.
I can't tell why that was added, so I've removed it and everything seems to be working.