### PR TITLE
8071530, 8274840: Two backporting changes for fixing win10 and 11

### DIFF
--- a/hotspot/src/os/windows/vm/os_windows.cpp
+++ b/hotspot/src/os/windows/vm/os_windows.cpp
@@ -1807,7 +1807,7 @@ void os::win32::print_windows_version(outputStream* st) {
     }
     break;
 
-  case 6004:
+  case 10000:
     if (is_workstation) {
       st->print("10");
     } else {

--- a/hotspot/src/os/windows/vm/os_windows.cpp
+++ b/hotspot/src/os/windows/vm/os_windows.cpp
@@ -1809,7 +1809,11 @@ void os::win32::print_windows_version(outputStream* st) {
 
   case 10000:
     if (is_workstation) {
-      st->print("10");
+      if (build_number >= 22000) {
+        st->print("11");
+      } else {
+        st->print("10");
+      }
     } else {
       // distinguish Windows Server by build number
       // - 2016 GA 10/2016 build: 14393

--- a/jdk/src/windows/native/java/lang/java_props_md.c
+++ b/jdk/src/windows/native/java/lang/java_props_md.c
@@ -473,6 +473,8 @@ GetJavaProperties(JNIEnv* env)
          * Windows Server 2012          6               2  (!VER_NT_WORKSTATION)
          * Windows Server 2012 R2       6               3  (!VER_NT_WORKSTATION)
          * Windows 10                   10              0  (VER_NT_WORKSTATION)
+         * Windows 11                   10              0  (VER_NT_WORKSTATION)
+         *       where (buildNumber >= 22000)
          * Windows Server 2016          10              0  (!VER_NT_WORKSTATION)
          * Windows Server 2019          10              0  (!VER_NT_WORKSTATION)
          *       where (buildNumber > 17762)
@@ -546,7 +548,14 @@ GetJavaProperties(JNIEnv* env)
             } else if (majorVersion == 10) {
                 if (is_workstation) {
                     switch (minorVersion) {
-                    case  0: sprops.os_name = "Windows 10";           break;
+                    case  0:
+                        /* Windows 11 21H2 (original release) build number is 22000 */
+                        if (buildNumber >= 22000) {
+                            sprops.os_name = "Windows 11";
+                        } else {
+                            sprops.os_name = "Windows 10";
+                        }
+                        break;
                     default: sprops.os_name = "Windows NT (unknown)";
                     }
                 } else {


### PR DESCRIPTION
### Description

**8071530**
Backport https://bugs.openjdk.org/browse/JDK-8071530 to reflect Windows 10 when fetching `System.getProperty("os.name")`

Original fix in upstream: https://github.com/openjdk/jdk/commit/fa47cc3e215fe4bb7531ff1a78f3965e2e84ac9f

Backport is clean.

**8274840**
Backport https://bugs.openjdk.org/browse/JDK-8274840 to recognize win11.

Original fix in upstream: https://github.com/openjdk/jdk/commit/97ea9dd2f24f9f1fb9b9345a4202a825ee28e014

Backport is clean after changing file paths.

### How has this been tested?
Verified on win11.