### PR TITLE
Enable bundled zlib library via Gradle

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -60,6 +60,9 @@ task configureBuild(type: Exec) {
     def command = ['bash', 'configure',
             "--with-toolchain-type=clang",
             '--with-x']
+    if (project.correttoArch == "aarch64") {
+        command += "--with-zlib=bundled"
+    }
     // Common flags
     command += project.correttoCommonFlags
     commandLine command.flatten()

--- a/jdk/make/lib/CoreLibraries.gmk
+++ b/jdk/make/lib/CoreLibraries.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -266,6 +266,9 @@ ifeq ($(USE_EXTERNAL_LIBZ), true)
   LIBZIP_EXCLUDES += zlib
 else
   ZLIB_CPPFLAGS := -I$(JDK_TOPDIR)/src/share/native/java/util/zip/zlib
+  ifeq ($(OPENJDK_TARGET_OS), macosx)
+    ZLIB_CPPFLAGS += -DHAVE_UNISTD_H
+  endif
 endif
 
 BUILD_LIBZIP_REORDER :=


### PR DESCRIPTION
This change contains two backports from corretto-11 to corretto-8:
 - [8286582: Build fails on macos aarch64 when using --with-zlib=bundled](https://github.com/corretto/corretto-11/pull/267) Note that the change is slightly different from the corretto-11, see change description [here](https://github.com/openjdk/jdk8u-dev/pull/80)
 - [Enable bundled zlib library via Gradle](https://github.com/corretto/corretto-jdk/pull/78) will enable the bundled zlib on m1, see https://bugs.openjdk.org/browse/JDK-8286623 for additional details.