### PR TITLE
Persist unix-like permissions in windows zip files

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -19,9 +19,14 @@
 * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+import java.nio.file.Paths
+
 dependencies {
     compile project(path: ':openjdksrc', configuration: 'archives')
 }
+
+def imagesDir = file("$buildRoot/build/$jdkImageName/images")
+def packagingDir = file("$buildDir/packaging")
 
 task copySource(type: Copy) {
     dependsOn project.configurations.compile
@@ -51,78 +56,125 @@ task executeBuild(type: Exec) {
     commandLine 'make', 'clean', 'images'
 }
 
-task importAmazonCacerts(type: Exec) {
+task copyImages() {
     dependsOn executeBuild
-    workingDir "${executeBuild.workingDir}/build/${project.jdkImageName}/images/j2sdk-image"
+    outputs.dir(packagingDir)
+    doLast {
+        // Copy jdk
+        copy {
+            from "$imagesDir/j2sdk-image"
+            exclude '**/*.diz'
+            into "$packagingDir/jdk"
+        }
+        // Copy jre
+        copy {
+            from "$imagesDir/j2re-image"
+            exclude '**/*.diz'
+            into "$packagingDir/jre"
+        }
+        // Copy jdk debug symbols
+        copy {
+            from "$imagesDir/j2sdk-image"
+            include '**/*.diz'
+            into "$packagingDir/jdk-symbols"
+        }
+    }
+}
+
+task importAmazonCacerts(type: Exec) {
+    dependsOn copyImages
+    outputs.dir(packagingDir)
+    workingDir "$imagesDir/j2sdk-image"
     // Default password for JSSE key store
     def keystore_password = "changeit"
     commandLine 'keytool', '-importkeystore', '-noprompt',
             '-srckeystore', "$buildRoot/amazon-cacerts",
             '-srcstorepass', keystore_password,
-            '-destkeystore', "jre/lib/security/cacerts",
+            '-destkeystore', "$packagingDir/jdk/jre/lib/security/cacerts",
             '-deststorepass', keystore_password
 }
 
 task copyCacerts(type: Copy) {
     dependsOn importAmazonCacerts
-    def imageDir = "${executeBuild.workingDir}/build/${project.jdkImageName}/images"
-
-    from file("${imageDir}/j2sdk-image/jre/lib/security/cacerts")
-    into file("${imageDir}/j2re-image/lib/security")
+    from file("$packagingDir/jdk/jre/lib/security/cacerts")
+    into file("$packagingDir/jre/lib/security")
 }
 
-task copyImage() {
-    dependsOn copyCacerts
 
+
+task fixPermissions() {
+    dependsOn copyCacerts
+    def rel = Paths.get("$packagingDir/placeholder").relativize(imagesDir.toPath())
+    outputs.dir(packagingDir)
     doLast {
-        // Copy image
-        copy {
-            from "${executeBuild.workingDir}/build/${project.jdkImageName}/images"
-            into "$buildRoot/build"
+        exec {
+            workingDir "$packagingDir/jdk"
+            commandLine 'bash', '-c', "find . -exec chmod --reference=\$(cygpath -u \'$rel\')/j2sdk-image/{} {} \\;"
         }
+        exec {
+            workingDir "$packagingDir/jre"
+            commandLine 'bash', '-c', "find . -exec chmod --reference=\$(cygpath -u \'$rel\')/j2re-image/{} {} \\;"
+        }
+        exec {
+            workingDir "$packagingDir/jdk-symbols"
+            commandLine 'bash', '-c', "find . -exec chmod --reference=\$(cygpath -u \'$rel\')/j2sdk-image/{} {} \\;"
+        }
+    }
+}
+
+task copyVersionInfo() {
+    dependsOn fixPermissions
+    outputs.dir(packagingDir)
+    doLast {
         // Copy version.txt into JDK
         copy {
             from "$buildRoot"
             include "commitId.txt"
             include "version.txt"
-            into "$buildRoot/build/j2sdk-image"
+            into "$packagingDir/jdk"
         }
         // Copy version.txt into JRE
         copy {
             from "$buildRoot"
             include "commitId.txt"
             include "version.txt"
-            into "$buildRoot/build/j2re-image"
+            into "$packagingDir/jre"
         }
     }
 }
 
-task packageDebugSymbols(type: Zip) {
-    dependsOn copyImage
-    archiveName  = "unsigned-jdk-debugsymbols-image.${project.correttoArch}.zip"
-
-    from ("$buildRoot/build/j2sdk-image") {
-        include '**/*.diz'
-    }
+task packageDebugSymbols(type: Exec) {
+    dependsOn copyVersionInfo
+    outputs.dir(distributionDir)
+    distributionDir.mkdirs()
+    def archiveName = file("$distributionDir/unsigned-jdk-debugsymbols-image.${project.correttoArch}.zip")
+    workingDir "$packagingDir/jdk-symbols"
+    commandLine 'bash', '-c', "zip -qr \$(cygpath -u \'$archiveName\') *"
+    artifacts.add('archives', archiveName)
 }
 
-task packageJdk(type: Zip) {
+task packageJdk(type: Exec) {
+    dependsOn copyVersionInfo
+    outputs.dir(distributionDir)
+    distributionDir.mkdirs()
+    def archiveName = file("$distributionDir/unsigned-jdk-image.${project.correttoArch}.zip")
+    workingDir "$packagingDir/jdk"
+    commandLine 'bash', '-c', "zip -qr \$(cygpath -u \'$archiveName\') *"
+    artifacts.add('archives', archiveName)
+}
+
+task packageJre(type: Exec) {
+    dependsOn copyVersionInfo
+    outputs.dir(distributionDir)
+    distributionDir.mkdirs()
+    def archiveName = file("$distributionDir/unsigned-jre-image.${project.correttoArch}.zip")
+    workingDir "$packagingDir/jre"
+    commandLine 'bash', '-c', "zip -qr \$(cygpath -u \'$archiveName\') *"
+    artifacts.add('archives', archiveName)
+}
+
+build {
     dependsOn packageDebugSymbols
-    archiveName  = "unsigned-jdk-image.${project.correttoArch}.zip"
-
-    from("$buildRoot/build/j2sdk-image") {
-        exclude '**/*.diz'
-    }
-}
-
-task packageJre(type: Zip) {
-    dependsOn copyImage
-    archiveName = "unsigned-jre-image.${project.correttoArch}.zip"
-
-    from "$buildRoot/build/j2re-image"
-}
-
-artifacts {
-    archives packageJdk
-    archives packageJre
+    dependsOn packageJre
+    dependsOn packageJdk
 }


### PR DESCRIPTION
Our current build logic produces zip files that contain unix file permission metadata, but the permission information is incorrect. This means that if the zip files are extracted by a posix aware application, they will extract the files with the wrong permission. An example of this would be the cygwin version of `unzip`. Because the tool is posix aware, and from it's perspective is running in a posix system, by default it will try to restore the permissions present in the zip file metadata. From cygwin perspective, those permissions will be applied. This includes not giving execute permissions to the different `.exe` and `.dll` files, which will cause issues.

Fixing this is not a trivial task. Although the gradle zip task is able to write those permissions, gradle in cygwin is running on top of a win32 VM. It bypasses the cygwin posix implementation completely. That is why files copied (or zipped) within gradle will have the default permission (644 for files, 755 for directories) regardless of what permissions they had originally. In order to fix this, we need to ensure the final zipping is done with a posix aware application, and that the permissions in the folder we zip are correct.

This is done by setting a packaging dir where we stage the desired files. A call to find/chmod will restore the original permissions, and we use zip directly instead of the zip task for generating the final file.

Ensuring we pick the proper version of `find` and `zip` is not trivial, as win32 versions of those tools exist, and `find` is even present in the `Windows\System32` folder. This is problematic because gradle may decide to find those tools instead of the cygwin ones during the exec task. This happens because even if cygwin will convert the `PATH` environment variable from the Windows format to the Unix format for posix apps, it won't do the reverse. If `c:\bin` is in the path, a posix app will see `/cygdrive/c/bin`, but if `/usr/bin` is in the path, a W32 app will not see `c:\tools\cygwin\rootdir\bin` (if that is where the folder maps to). In order to minimize this, we make calls go through `bash` first. This solves a very common scenario. If `$PATH` looks like `/usr/bin:/cygdrive/c/Windows/System32:/cygdrive/c/tools/cygwin/root/bin`, asking gradle to execute `find.exe` will find `C:\Windows\System32\find.exe` first, as the `/usr/bin` is ignored. By calling `bash -c find`, gradle will find bash in `c:\tools\cygwin\root\bin\bash.exe` and then bash will receive the full env, understand `/usr/bin` and locate `/usr/bin/find.exe`. Same for zip (although not present in the `c:\windows\system32` it is possible it is still located with higher priority by win32 applications than the cygwin zip