### PR TITLE
Support C++17 removal of register

### DIFF
--- a/hotspot/src/os_cpu/aix_ppc/vm/orderAccess_aix_ppc.inline.hpp
+++ b/hotspot/src/os_cpu/aix_ppc/vm/orderAccess_aix_ppc.inline.hpp
@@ -79,16 +79,16 @@ inline void     OrderAccess::acquire()    { inlasm_acquire(); }
 inline void     OrderAccess::release()    { inlasm_release(); }
 inline void     OrderAccess::fence()      { inlasm_fence();   }
 
-inline jbyte    OrderAccess::load_acquire(volatile jbyte*   p) { register jbyte t = *p;   inlasm_acquire_reg(t); return t; }
-inline jshort   OrderAccess::load_acquire(volatile jshort*  p) { register jshort t = *p;  inlasm_acquire_reg(t); return t; }
-inline jint     OrderAccess::load_acquire(volatile jint*    p) { register jint t = *p;    inlasm_acquire_reg(t); return t; }
-inline jlong    OrderAccess::load_acquire(volatile jlong*   p) { register jlong t = *p;   inlasm_acquire_reg(t); return t; }
-inline jubyte   OrderAccess::load_acquire(volatile jubyte*  p) { register jubyte t = *p;  inlasm_acquire_reg(t); return t; }
-inline jushort  OrderAccess::load_acquire(volatile jushort* p) { register jushort t = *p; inlasm_acquire_reg(t); return t; }
-inline juint    OrderAccess::load_acquire(volatile juint*   p) { register juint t = *p;   inlasm_acquire_reg(t); return t; }
+inline jbyte    OrderAccess::load_acquire(volatile jbyte*   p) { REGISTER jbyte t = *p;   inlasm_acquire_reg(t); return t; }
+inline jshort   OrderAccess::load_acquire(volatile jshort*  p) { REGISTER jshort t = *p;  inlasm_acquire_reg(t); return t; }
+inline jint     OrderAccess::load_acquire(volatile jint*    p) { REGISTER jint t = *p;    inlasm_acquire_reg(t); return t; }
+inline jlong    OrderAccess::load_acquire(volatile jlong*   p) { REGISTER jlong t = *p;   inlasm_acquire_reg(t); return t; }
+inline jubyte   OrderAccess::load_acquire(volatile jubyte*  p) { REGISTER jubyte t = *p;  inlasm_acquire_reg(t); return t; }
+inline jushort  OrderAccess::load_acquire(volatile jushort* p) { REGISTER jushort t = *p; inlasm_acquire_reg(t); return t; }
+inline juint    OrderAccess::load_acquire(volatile juint*   p) { REGISTER juint t = *p;   inlasm_acquire_reg(t); return t; }
 inline julong   OrderAccess::load_acquire(volatile julong*  p) { return (julong)load_acquire((volatile jlong*)p); }
-inline jfloat   OrderAccess::load_acquire(volatile jfloat*  p) { register jfloat t = *p;  inlasm_acquire(); return t; }
-inline jdouble  OrderAccess::load_acquire(volatile jdouble* p) { register jdouble t = *p; inlasm_acquire(); return t; }
+inline jfloat   OrderAccess::load_acquire(volatile jfloat*  p) { REGISTER jfloat t = *p;  inlasm_acquire(); return t; }
+inline jdouble  OrderAccess::load_acquire(volatile jdouble* p) { REGISTER jdouble t = *p; inlasm_acquire(); return t; }
 
 inline intptr_t OrderAccess::load_ptr_acquire(volatile intptr_t*   p) { return (intptr_t)load_acquire((volatile jlong*)p); }
 inline void*    OrderAccess::load_ptr_acquire(volatile void*       p) { return (void*)   load_acquire((volatile jlong*)p); }

--- a/hotspot/src/os_cpu/aix_ppc/vm/orderAccess_aix_ppc.inline.hpp
+++ b/hotspot/src/os_cpu/aix_ppc/vm/orderAccess_aix_ppc.inline.hpp
@@ -79,16 +79,16 @@ inline void     OrderAccess::acquire()    { inlasm_acquire(); }
 inline void     OrderAccess::release()    { inlasm_release(); }
 inline void     OrderAccess::fence()      { inlasm_fence();   }
 
-inline jbyte    OrderAccess::load_acquire(volatile jbyte*   p) { jbyte t = *p;   inlasm_acquire_reg(t); return t; }
-inline jshort   OrderAccess::load_acquire(volatile jshort*  p) { jshort t = *p;  inlasm_acquire_reg(t); return t; }
-inline jint     OrderAccess::load_acquire(volatile jint*    p) { jint t = *p;    inlasm_acquire_reg(t); return t; }
-inline jlong    OrderAccess::load_acquire(volatile jlong*   p) { jlong t = *p;   inlasm_acquire_reg(t); return t; }
-inline jubyte   OrderAccess::load_acquire(volatile jubyte*  p) { jubyte t = *p;  inlasm_acquire_reg(t); return t; }
-inline jushort  OrderAccess::load_acquire(volatile jushort* p) { jushort t = *p; inlasm_acquire_reg(t); return t; }
-inline juint    OrderAccess::load_acquire(volatile juint*   p) { juint t = *p;   inlasm_acquire_reg(t); return t; }
+inline jbyte    OrderAccess::load_acquire(volatile jbyte*   p) { register jbyte t = *p;   inlasm_acquire_reg(t); return t; }
+inline jshort   OrderAccess::load_acquire(volatile jshort*  p) { register jshort t = *p;  inlasm_acquire_reg(t); return t; }
+inline jint     OrderAccess::load_acquire(volatile jint*    p) { register jint t = *p;    inlasm_acquire_reg(t); return t; }
+inline jlong    OrderAccess::load_acquire(volatile jlong*   p) { register jlong t = *p;   inlasm_acquire_reg(t); return t; }
+inline jubyte   OrderAccess::load_acquire(volatile jubyte*  p) { register jubyte t = *p;  inlasm_acquire_reg(t); return t; }
+inline jushort  OrderAccess::load_acquire(volatile jushort* p) { register jushort t = *p; inlasm_acquire_reg(t); return t; }
+inline juint    OrderAccess::load_acquire(volatile juint*   p) { register juint t = *p;   inlasm_acquire_reg(t); return t; }
 inline julong   OrderAccess::load_acquire(volatile julong*  p) { return (julong)load_acquire((volatile jlong*)p); }
-inline jfloat   OrderAccess::load_acquire(volatile jfloat*  p) { jfloat t = *p;  inlasm_acquire(); return t; }
-inline jdouble  OrderAccess::load_acquire(volatile jdouble* p) { jdouble t = *p; inlasm_acquire(); return t; }
+inline jfloat   OrderAccess::load_acquire(volatile jfloat*  p) { register jfloat t = *p;  inlasm_acquire(); return t; }
+inline jdouble  OrderAccess::load_acquire(volatile jdouble* p) { register jdouble t = *p; inlasm_acquire(); return t; }
 
 inline intptr_t OrderAccess::load_ptr_acquire(volatile intptr_t*   p) { return (intptr_t)load_acquire((volatile jlong*)p); }
 inline void*    OrderAccess::load_ptr_acquire(volatile void*       p) { return (void*)   load_acquire((volatile jlong*)p); }

--- a/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
+++ b/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
@@ -94,11 +94,12 @@ PRAGMA_FORMAT_MUTE_WARNINGS_FOR_GCC
 
 address os::current_stack_pointer() {
 #ifdef SPARC_WORKS
-  void *esp;
+  register void *esp;
   __asm__("mov %%"SPELL_REG_SP", %0":"=r"(esp));
   return (address) ((char*)esp + sizeof(long)*2);
 #else
-  return (address)__builtin_frame_address(0);
+  register void *esp __asm__ (SPELL_REG_SP);
+  return (address) esp;
 #endif
 }
 
@@ -176,13 +177,13 @@ frame os::get_sender_for_C_frame(frame* fr) {
 
 intptr_t* _get_previous_fp() {
 #ifdef SPARC_WORKS
-  intptr_t **ebp;
+  register intptr_t **ebp;
   __asm__("mov %%"SPELL_REG_FP", %0":"=r"(ebp));
 #elif defined(__clang__)
   intptr_t **ebp;
   __asm__ __volatile__ ("mov %%"SPELL_REG_FP", %0":"=r"(ebp):);
 #else
-  intptr_t **ebp __asm__ (SPELL_REG_FP);
+  register intptr_t **ebp __asm__ (SPELL_REG_FP);
 #endif
   return (intptr_t*) *ebp;   // we want what it points to.
 }

--- a/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
+++ b/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
@@ -94,11 +94,11 @@ PRAGMA_FORMAT_MUTE_WARNINGS_FOR_GCC
 
 address os::current_stack_pointer() {
 #ifdef SPARC_WORKS
-  register void *esp;
+  REGISTER void *esp;
   __asm__("mov %%"SPELL_REG_SP", %0":"=r"(esp));
   return (address) ((char*)esp + sizeof(long)*2);
 #else
-  register void *esp __asm__ (SPELL_REG_SP);
+  REGISTER void *esp __asm__ (SPELL_REG_SP);
   return (address) esp;
 #endif
 }
@@ -177,13 +177,13 @@ frame os::get_sender_for_C_frame(frame* fr) {
 
 intptr_t* _get_previous_fp() {
 #ifdef SPARC_WORKS
-  register intptr_t **ebp;
+  REGISTER intptr_t **ebp;
   __asm__("mov %%"SPELL_REG_FP", %0":"=r"(ebp));
 #elif defined(__clang__)
   intptr_t **ebp;
   __asm__ __volatile__ ("mov %%"SPELL_REG_FP", %0":"=r"(ebp):);
 #else
-  register intptr_t **ebp __asm__ (SPELL_REG_FP);
+  REGISTER intptr_t **ebp __asm__ (SPELL_REG_FP);
 #endif
   return (intptr_t*) *ebp;   // we want what it points to.
 }

--- a/hotspot/src/share/vm/adlc/adlc.hpp
+++ b/hotspot/src/share/vm/adlc/adlc.hpp
@@ -75,6 +75,17 @@ typedef unsigned int uintptr_t;
 #define uint32 unsigned int
 #define uint   unsigned int
 
+// register keyword is no longer supported in c++17, but causes issues if removed
+// see also:
+// https://github.com/openjdk/jdk8u-dev/pull/11
+// https://bugs.openjdk.org/browse/JDK-8281098
+// https://github.com/corretto/corretto-8/issues/411
+#if defined(__cplusplus) && __cplusplus>=201703L
+#define REGISTER
+#else
+#define REGISTER register
+#endif
+
 // VM components
 #include "opto/opcodes.hpp"
 

--- a/hotspot/src/share/vm/adlc/adlparse.cpp
+++ b/hotspot/src/share/vm/adlc/adlparse.cpp
@@ -4564,7 +4564,7 @@ char *ADLParser::get_paren_expr(const char *description, bool include_location) 
 // string(still inside the file buffer).  Returns a pointer to the string or
 // NULL if some other token is found instead.
 char *ADLParser::get_ident_common(bool do_preproc) {
-  register char c;
+  REGISTER char c;
   char *start;                    // Pointer to start of token
   char *end;                      // Pointer to end of token
 
@@ -4762,7 +4762,7 @@ char *ADLParser::get_unique_ident(FormDict& dict, const char* nameDescription){
 // invokes a parse_err if the next token is not an integer.
 // This routine does not leave the integer null-terminated.
 int ADLParser::get_int(void) {
-  register char c;
+  REGISTER char c;
   char         *start;            // Pointer to start of token
   char         *end;              // Pointer to end of token
   int           result;           // Storage for integer result

--- a/hotspot/src/share/vm/adlc/adlparse.cpp
+++ b/hotspot/src/share/vm/adlc/adlparse.cpp
@@ -4564,7 +4564,7 @@ char *ADLParser::get_paren_expr(const char *description, bool include_location) 
 // string(still inside the file buffer).  Returns a pointer to the string or
 // NULL if some other token is found instead.
 char *ADLParser::get_ident_common(bool do_preproc) {
-  char c;
+  register char c;
   char *start;                    // Pointer to start of token
   char *end;                      // Pointer to end of token
 
@@ -4762,7 +4762,7 @@ char *ADLParser::get_unique_ident(FormDict& dict, const char* nameDescription){
 // invokes a parse_err if the next token is not an integer.
 // This routine does not leave the integer null-terminated.
 int ADLParser::get_int(void) {
-  char c;
+  register char c;
   char         *start;            // Pointer to start of token
   char         *end;              // Pointer to end of token
   int           result;           // Storage for integer result

--- a/hotspot/src/share/vm/adlc/arena.cpp
+++ b/hotspot/src/share/vm/adlc/arena.cpp
@@ -79,7 +79,7 @@ Arena::Arena( Arena *a )
 // Total of all Chunks in arena
 size_t Arena::used() const {
   size_t sum = _chunk->_len - (_max-_hwm); // Size leftover in this Chunk
-  Chunk *k = _first;
+  register Chunk *k = _first;
   while( k != _chunk) {         // Whilst have Chunks in a row
     sum += k->_len;             // Total size of this Chunk
     k = k->_next;               // Bump along to next Chunk
@@ -93,7 +93,7 @@ void* Arena::grow( size_t x ) {
   // Get minimal required size.  Either real big, or even bigger for giant objs
   size_t len = max(x, Chunk::size);
 
-  Chunk *k = _chunk;   // Get filled-up chunk address
+  register Chunk *k = _chunk;   // Get filled-up chunk address
   _chunk = new (len) Chunk(len);
 
   if( k ) k->_next = _chunk;    // Append new chunk to end of linked list

--- a/hotspot/src/share/vm/adlc/arena.cpp
+++ b/hotspot/src/share/vm/adlc/arena.cpp
@@ -79,7 +79,7 @@ Arena::Arena( Arena *a )
 // Total of all Chunks in arena
 size_t Arena::used() const {
   size_t sum = _chunk->_len - (_max-_hwm); // Size leftover in this Chunk
-  register Chunk *k = _first;
+  REGISTER Chunk *k = _first;
   while( k != _chunk) {         // Whilst have Chunks in a row
     sum += k->_len;             // Total size of this Chunk
     k = k->_next;               // Bump along to next Chunk
@@ -93,7 +93,7 @@ void* Arena::grow( size_t x ) {
   // Get minimal required size.  Either real big, or even bigger for giant objs
   size_t len = max(x, Chunk::size);
 
-  register Chunk *k = _chunk;   // Get filled-up chunk address
+  REGISTER Chunk *k = _chunk;   // Get filled-up chunk address
   _chunk = new (len) Chunk(len);
 
   if( k ) k->_next = _chunk;    // Append new chunk to end of linked list

--- a/hotspot/src/share/vm/adlc/dict2.cpp
+++ b/hotspot/src/share/vm/adlc/dict2.cpp
@@ -283,9 +283,9 @@ void Dict::print(PrintKeyOrValue print_key, PrintKeyOrValue print_value) {
 // limited to MAXID characters in length.  Experimental evidence on 150K of
 // C text shows excellent spreading of values for any size hash table.
 int hashstr(const void *t) {
-  register char c, k = 0;
-  register int sum = 0;
-  register const char *s = (const char *)t;
+  REGISTER char c, k = 0;
+  REGISTER int sum = 0;
+  REGISTER const char *s = (const char *)t;
 
   while (((c = s[k]) != '\0') && (k < MAXID-1)) { // Get characters till nul
     c = (char) ((c << 1) + 1);    // Characters are always odd!

--- a/hotspot/src/share/vm/adlc/dict2.cpp
+++ b/hotspot/src/share/vm/adlc/dict2.cpp
@@ -283,9 +283,9 @@ void Dict::print(PrintKeyOrValue print_key, PrintKeyOrValue print_value) {
 // limited to MAXID characters in length.  Experimental evidence on 150K of
 // C text shows excellent spreading of values for any size hash table.
 int hashstr(const void *t) {
-  char c, k = 0;
-  int sum = 0;
-  const char *s = (const char *)t;
+  register char c, k = 0;
+  register int sum = 0;
+  register const char *s = (const char *)t;
 
   while (((c = s[k]) != '\0') && (k < MAXID-1)) { // Get characters till nul
     c = (char) ((c << 1) + 1);    // Characters are always odd!

--- a/hotspot/src/share/vm/adlc/main.cpp
+++ b/hotspot/src/share/vm/adlc/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 
   // Read command line arguments and file names
   for( int i = 1; i < argc; i++ ) { // For all arguments
-    register char *s = argv[i]; // Get option/filename
+    REGISTER char *s = argv[i]; // Get option/filename
 
     if( *s++ == '-' ) {         // It's a flag? (not a filename)
       if( !*s ) {               // Stand-alone `-' means stdin

--- a/hotspot/src/share/vm/adlc/main.cpp
+++ b/hotspot/src/share/vm/adlc/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 
   // Read command line arguments and file names
   for( int i = 1; i < argc; i++ ) { // For all arguments
-    char *s = argv[i]; // Get option/filename
+    register char *s = argv[i]; // Get option/filename
 
     if( *s++ == '-' ) {         // It's a flag? (not a filename)
       if( !*s ) {               // Stand-alone `-' means stdin

--- a/hotspot/src/share/vm/interpreter/bytecodeInterpreter.cpp
+++ b/hotspot/src/share/vm/interpreter/bytecodeInterpreter.cpp
@@ -508,13 +508,13 @@ BytecodeInterpreter::run(interpreterState istate) {
   interpreterState orig = istate;
 #endif
 
-  intptr_t*        topOfStack = (intptr_t *)istate->stack(); /* access with STACK macros */
-  address          pc = istate->bcp();
-  jubyte opcode;
-  intptr_t*        locals = istate->locals();
-  ConstantPoolCache*    cp = istate->constants(); // method()->constants()->cache()
+  register intptr_t*        topOfStack = (intptr_t *)istate->stack(); /* access with STACK macros */
+  register address          pc = istate->bcp();
+  register jubyte opcode;
+  register intptr_t*        locals = istate->locals();
+  register ConstantPoolCache*    cp = istate->constants(); // method()->constants()->cache()
 #ifdef LOTS_OF_REGS
-  JavaThread*      THREAD = istate->thread();
+  register JavaThread*      THREAD = istate->thread();
 #else
 #undef THREAD
 #define THREAD istate->thread()
@@ -603,7 +603,7 @@ BytecodeInterpreter::run(interpreterState istate) {
 /* 0xF8 */ &&opc_default,     &&opc_default,        &&opc_default,      &&opc_default,
 /* 0xFC */ &&opc_default,     &&opc_default,        &&opc_default,      &&opc_default
   };
-  uintptr_t *dispatch_table = (uintptr_t*)&opclabels_data[0];
+  register uintptr_t *dispatch_table = (uintptr_t*)&opclabels_data[0];
 #endif /* USELABELS */
 
 #ifdef ASSERT

--- a/hotspot/src/share/vm/interpreter/bytecodeInterpreter.cpp
+++ b/hotspot/src/share/vm/interpreter/bytecodeInterpreter.cpp
@@ -508,13 +508,13 @@ BytecodeInterpreter::run(interpreterState istate) {
   interpreterState orig = istate;
 #endif
 
-  register intptr_t*        topOfStack = (intptr_t *)istate->stack(); /* access with STACK macros */
-  register address          pc = istate->bcp();
-  register jubyte opcode;
-  register intptr_t*        locals = istate->locals();
-  register ConstantPoolCache*    cp = istate->constants(); // method()->constants()->cache()
+  REGISTER intptr_t*        topOfStack = (intptr_t *)istate->stack(); /* access with STACK macros */
+  REGISTER address          pc = istate->bcp();
+  REGISTER jubyte opcode;
+  REGISTER intptr_t*        locals = istate->locals();
+  REGISTER ConstantPoolCache*    cp = istate->constants(); // method()->constants()->cache()
 #ifdef LOTS_OF_REGS
-  register JavaThread*      THREAD = istate->thread();
+  REGISTER JavaThread*      THREAD = istate->thread();
 #else
 #undef THREAD
 #define THREAD istate->thread()
@@ -603,7 +603,7 @@ BytecodeInterpreter::run(interpreterState istate) {
 /* 0xF8 */ &&opc_default,     &&opc_default,        &&opc_default,      &&opc_default,
 /* 0xFC */ &&opc_default,     &&opc_default,        &&opc_default,      &&opc_default
   };
-  register uintptr_t *dispatch_table = (uintptr_t*)&opclabels_data[0];
+  REGISTER uintptr_t *dispatch_table = (uintptr_t*)&opclabels_data[0];
 #endif /* USELABELS */
 
 #ifdef ASSERT

--- a/hotspot/src/share/vm/libadt/dict.cpp
+++ b/hotspot/src/share/vm/libadt/dict.cpp
@@ -319,9 +319,9 @@ void Dict::print() {
 // limited to MAXID characters in length.  Experimental evidence on 150K of
 // C text shows excellent spreading of values for any size hash table.
 int hashstr(const void *t) {
-  register char c, k = 0;
-  register int32 sum = 0;
-  register const char *s = (const char *)t;
+  REGISTER char c, k = 0;
+  REGISTER int32 sum = 0;
+  REGISTER const char *s = (const char *)t;
 
   while( ((c = *s++) != '\0') && (k < MAXID-1) ) { // Get characters till null or MAXID-1
     c = (c<<1)+1;               // Characters are always odd!

--- a/hotspot/src/share/vm/libadt/dict.cpp
+++ b/hotspot/src/share/vm/libadt/dict.cpp
@@ -319,9 +319,9 @@ void Dict::print() {
 // limited to MAXID characters in length.  Experimental evidence on 150K of
 // C text shows excellent spreading of values for any size hash table.
 int hashstr(const void *t) {
-  char c, k = 0;
-  int32 sum = 0;
-  const char *s = (const char *)t;
+  register char c, k = 0;
+  register int32 sum = 0;
+  register const char *s = (const char *)t;
 
   while( ((c = *s++) != '\0') && (k < MAXID-1) ) { // Get characters till null or MAXID-1
     c = (c<<1)+1;               // Characters are always odd!

--- a/hotspot/src/share/vm/libadt/set.cpp
+++ b/hotspot/src/share/vm/libadt/set.cpp
@@ -73,7 +73,7 @@ char *Set::setstr() const
   uint len = 128;               // Total string space
   char *buf = NEW_C_HEAP_ARRAY(char,len, mtCompiler);// Some initial string space
 
-  char *s = buf;       // Current working string pointer
+  register char *s = buf;       // Current working string pointer
   *s++ = '{';
   *s = '\0';
 
@@ -125,8 +125,8 @@ void Set::print() const
 // Set.  Return the amount of text parsed in "len", or zero in "len".
 int Set::parse(const char *s)
 {
-  char c;              // Parse character
-  const char *t = s;   // Save the starting position of s.
+  register char c;              // Parse character
+  register const char *t = s;   // Save the starting position of s.
   do c = *s++;                  // Skip characters
   while( c && (c <= ' ') );     // Till no more whitespace or EOS
   if( c != '{' ) return 0;      // Oops, not a Set openner

--- a/hotspot/src/share/vm/libadt/set.cpp
+++ b/hotspot/src/share/vm/libadt/set.cpp
@@ -73,7 +73,7 @@ char *Set::setstr() const
   uint len = 128;               // Total string space
   char *buf = NEW_C_HEAP_ARRAY(char,len, mtCompiler);// Some initial string space
 
-  register char *s = buf;       // Current working string pointer
+  REGISTER char *s = buf;       // Current working string pointer
   *s++ = '{';
   *s = '\0';
 
@@ -125,8 +125,8 @@ void Set::print() const
 // Set.  Return the amount of text parsed in "len", or zero in "len".
 int Set::parse(const char *s)
 {
-  register char c;              // Parse character
-  register const char *t = s;   // Save the starting position of s.
+  REGISTER char c;              // Parse character
+  REGISTER const char *t = s;   // Save the starting position of s.
   do c = *s++;                  // Skip characters
   while( c && (c <= ' ') );     // Till no more whitespace or EOS
   if( c != '{' ) return 0;      // Oops, not a Set openner

--- a/hotspot/src/share/vm/libadt/vectset.cpp
+++ b/hotspot/src/share/vm/libadt/vectset.cpp
@@ -105,8 +105,8 @@ void VectorSet::grow( uint newsize )
 // Insert a member into an existing Set.
 Set &VectorSet::operator <<= (uint elem)
 {
-  register uint word = elem >> 5;            // Get the longword offset
-  register uint32 mask = 1L << (elem & 31);  // Get bit mask
+  REGISTER uint word = elem >> 5;            // Get the longword offset
+  REGISTER uint32 mask = 1L << (elem & 31);  // Get bit mask
 
   if( word >= size )            // Need to grow set?
     grow(elem+1);               // Then grow it
@@ -118,10 +118,10 @@ Set &VectorSet::operator <<= (uint elem)
 // Delete a member from an existing Set.
 Set &VectorSet::operator >>= (uint elem)
 {
-  register uint word = elem >> 5; // Get the longword offset
+  REGISTER uint word = elem >> 5; // Get the longword offset
   if( word >= size )              // Beyond the last?
     return *this;                 // Then it's clear & return clear
-  register uint32 mask = 1L << (elem & 31);     // Get bit mask
+  REGISTER uint32 mask = 1L << (elem & 31);     // Get bit mask
   data[word] &= ~mask;            // Clear bit
   return *this;
 }
@@ -132,8 +132,8 @@ VectorSet &VectorSet::operator &= (const VectorSet &s)
 {
   // NOTE: The intersection is never any larger than the smallest set.
   if( s.size < size ) size = s.size; // Get smaller size
-  register uint32 *u1 = data;   // Pointer to the destination data
-  register uint32 *u2 = s.data; // Pointer to the source data
+  REGISTER uint32 *u1 = data;   // Pointer to the destination data
+  REGISTER uint32 *u2 = s.data; // Pointer to the source data
   for( uint i=0; i<size; i++)   // For data in set
     *u1++ &= *u2++;             // Copy and AND longwords
   return *this;                 // Return set
@@ -151,9 +151,9 @@ Set &VectorSet::operator &= (const Set &set)
 VectorSet &VectorSet::operator |= (const VectorSet &s)
 {
   // This many words must be unioned
-  register uint cnt = ((size<s.size)?size:s.size);
-  register uint32 *u1 = data;   // Pointer to the destination data
-  register uint32 *u2 = s.data; // Pointer to the source data
+  REGISTER uint cnt = ((size<s.size)?size:s.size);
+  REGISTER uint32 *u1 = data;   // Pointer to the destination data
+  REGISTER uint32 *u2 = s.data; // Pointer to the source data
   for( uint i=0; i<cnt; i++)    // Copy and OR the two sets
     *u1++ |= *u2++;
   if( size < s.size ) {         // Is set 2 larger than set 1?
@@ -176,9 +176,9 @@ Set &VectorSet::operator |= (const Set &set)
 VectorSet &VectorSet::operator -= (const VectorSet &s)
 {
   // This many words must be unioned
-  register uint cnt = ((size<s.size)?size:s.size);
-  register uint32 *u1 = data;   // Pointer to the destination data
-  register uint32 *u2 = s.data; // Pointer to the source data
+  REGISTER uint cnt = ((size<s.size)?size:s.size);
+  REGISTER uint32 *u1 = data;   // Pointer to the destination data
+  REGISTER uint32 *u2 = s.data; // Pointer to the source data
   for( uint i=0; i<cnt; i++ )   // For data in set
     *u1++ &= ~(*u2++);          // A <-- A & ~B  with longwords
   return *this;                 // Return new set
@@ -199,17 +199,17 @@ Set &VectorSet::operator -= (const Set &set)
 //        1X --  B is a subset of A
 int VectorSet::compare (const VectorSet &s) const
 {
-  register uint32 *u1 = data;   // Pointer to the destination data
-  register uint32 *u2 = s.data; // Pointer to the source data
-  register uint32 AnotB = 0, BnotA = 0;
+  REGISTER uint32 *u1 = data;   // Pointer to the destination data
+  REGISTER uint32 *u2 = s.data; // Pointer to the source data
+  REGISTER uint32 AnotB = 0, BnotA = 0;
   // This many words must be unioned
-  register uint cnt = ((size<s.size)?size:s.size);
+  REGISTER uint cnt = ((size<s.size)?size:s.size);
 
   // Get bits for both sets
   uint i;                       // Exit value of loop
   for( i=0; i<cnt; i++ ) {      // For data in BOTH sets
-    register uint32 A = *u1++;  // Data from one guy
-    register uint32 B = *u2++;  // Data from other guy
+    REGISTER uint32 A = *u1++;  // Data from one guy
+    REGISTER uint32 B = *u2++;  // Data from other guy
     AnotB |= (A & ~B);          // Compute bits in A not B
     BnotA |= (B & ~A);          // Compute bits in B not A
   }
@@ -249,9 +249,9 @@ int VectorSet::disjoint(const Set &set) const
   const VectorSet &s = *(set.asVectorSet());
 
   // NOTE: The intersection is never any larger than the smallest set.
-  register uint small_size = ((size<s.size)?size:s.size);
-  register uint32 *u1 = data;        // Pointer to the destination data
-  register uint32 *u2 = s.data;      // Pointer to the source data
+  REGISTER uint small_size = ((size<s.size)?size:s.size);
+  REGISTER uint32 *u1 = data;        // Pointer to the destination data
+  REGISTER uint32 *u2 = s.data;      // Pointer to the source data
   for( uint i=0; i<small_size; i++)  // For data in set
     if( *u1++ & *u2++ )              // If any elements in common
       return 0;                      // Then not disjoint
@@ -290,10 +290,10 @@ int VectorSet::operator <= (const Set &set) const
 // Test for membership.  A Zero/Non-Zero value is returned!
 int VectorSet::operator[](uint elem) const
 {
-  register uint word = elem >> 5; // Get the longword offset
+  REGISTER uint word = elem >> 5; // Get the longword offset
   if( word >= size )              // Beyond the last?
     return 0;                     // Then it's clear
-  register uint32 mask = 1L << (elem & 31);  // Get bit mask
+  REGISTER uint32 mask = 1L << (elem & 31);  // Get bit mask
   return ((data[word] & mask))!=0;           // Return the sense of the bit
 }
 

--- a/hotspot/src/share/vm/libadt/vectset.cpp
+++ b/hotspot/src/share/vm/libadt/vectset.cpp
@@ -105,8 +105,8 @@ void VectorSet::grow( uint newsize )
 // Insert a member into an existing Set.
 Set &VectorSet::operator <<= (uint elem)
 {
-  uint word = elem >> 5;            // Get the longword offset
-  uint32 mask = 1L << (elem & 31);  // Get bit mask
+  register uint word = elem >> 5;            // Get the longword offset
+  register uint32 mask = 1L << (elem & 31);  // Get bit mask
 
   if( word >= size )            // Need to grow set?
     grow(elem+1);               // Then grow it
@@ -118,10 +118,10 @@ Set &VectorSet::operator <<= (uint elem)
 // Delete a member from an existing Set.
 Set &VectorSet::operator >>= (uint elem)
 {
-  uint word = elem >> 5; // Get the longword offset
+  register uint word = elem >> 5; // Get the longword offset
   if( word >= size )              // Beyond the last?
     return *this;                 // Then it's clear & return clear
-  uint32 mask = 1L << (elem & 31);     // Get bit mask
+  register uint32 mask = 1L << (elem & 31);     // Get bit mask
   data[word] &= ~mask;            // Clear bit
   return *this;
 }
@@ -132,8 +132,8 @@ VectorSet &VectorSet::operator &= (const VectorSet &s)
 {
   // NOTE: The intersection is never any larger than the smallest set.
   if( s.size < size ) size = s.size; // Get smaller size
-  uint32 *u1 = data;   // Pointer to the destination data
-  uint32 *u2 = s.data; // Pointer to the source data
+  register uint32 *u1 = data;   // Pointer to the destination data
+  register uint32 *u2 = s.data; // Pointer to the source data
   for( uint i=0; i<size; i++)   // For data in set
     *u1++ &= *u2++;             // Copy and AND longwords
   return *this;                 // Return set
@@ -151,9 +151,9 @@ Set &VectorSet::operator &= (const Set &set)
 VectorSet &VectorSet::operator |= (const VectorSet &s)
 {
   // This many words must be unioned
-  uint cnt = ((size<s.size)?size:s.size);
-  uint32 *u1 = data;   // Pointer to the destination data
-  uint32 *u2 = s.data; // Pointer to the source data
+  register uint cnt = ((size<s.size)?size:s.size);
+  register uint32 *u1 = data;   // Pointer to the destination data
+  register uint32 *u2 = s.data; // Pointer to the source data
   for( uint i=0; i<cnt; i++)    // Copy and OR the two sets
     *u1++ |= *u2++;
   if( size < s.size ) {         // Is set 2 larger than set 1?
@@ -176,9 +176,9 @@ Set &VectorSet::operator |= (const Set &set)
 VectorSet &VectorSet::operator -= (const VectorSet &s)
 {
   // This many words must be unioned
-  uint cnt = ((size<s.size)?size:s.size);
-  uint32 *u1 = data;   // Pointer to the destination data
-  uint32 *u2 = s.data; // Pointer to the source data
+  register uint cnt = ((size<s.size)?size:s.size);
+  register uint32 *u1 = data;   // Pointer to the destination data
+  register uint32 *u2 = s.data; // Pointer to the source data
   for( uint i=0; i<cnt; i++ )   // For data in set
     *u1++ &= ~(*u2++);          // A <-- A & ~B  with longwords
   return *this;                 // Return new set
@@ -199,17 +199,17 @@ Set &VectorSet::operator -= (const Set &set)
 //        1X --  B is a subset of A
 int VectorSet::compare (const VectorSet &s) const
 {
-  uint32 *u1 = data;   // Pointer to the destination data
-  uint32 *u2 = s.data; // Pointer to the source data
-  uint32 AnotB = 0, BnotA = 0;
+  register uint32 *u1 = data;   // Pointer to the destination data
+  register uint32 *u2 = s.data; // Pointer to the source data
+  register uint32 AnotB = 0, BnotA = 0;
   // This many words must be unioned
-  uint cnt = ((size<s.size)?size:s.size);
+  register uint cnt = ((size<s.size)?size:s.size);
 
   // Get bits for both sets
   uint i;                       // Exit value of loop
   for( i=0; i<cnt; i++ ) {      // For data in BOTH sets
-    uint32 A = *u1++;  // Data from one guy
-    uint32 B = *u2++;  // Data from other guy
+    register uint32 A = *u1++;  // Data from one guy
+    register uint32 B = *u2++;  // Data from other guy
     AnotB |= (A & ~B);          // Compute bits in A not B
     BnotA |= (B & ~A);          // Compute bits in B not A
   }
@@ -249,9 +249,9 @@ int VectorSet::disjoint(const Set &set) const
   const VectorSet &s = *(set.asVectorSet());
 
   // NOTE: The intersection is never any larger than the smallest set.
-  uint small_size = ((size<s.size)?size:s.size);
-  uint32 *u1 = data;        // Pointer to the destination data
-  uint32 *u2 = s.data;      // Pointer to the source data
+  register uint small_size = ((size<s.size)?size:s.size);
+  register uint32 *u1 = data;        // Pointer to the destination data
+  register uint32 *u2 = s.data;      // Pointer to the source data
   for( uint i=0; i<small_size; i++)  // For data in set
     if( *u1++ & *u2++ )              // If any elements in common
       return 0;                      // Then not disjoint
@@ -290,10 +290,10 @@ int VectorSet::operator <= (const Set &set) const
 // Test for membership.  A Zero/Non-Zero value is returned!
 int VectorSet::operator[](uint elem) const
 {
-  uint word = elem >> 5; // Get the longword offset
+  register uint word = elem >> 5; // Get the longword offset
   if( word >= size )              // Beyond the last?
     return 0;                     // Then it's clear
-  uint32 mask = 1L << (elem & 31);  // Get bit mask
+  register uint32 mask = 1L << (elem & 31);  // Get bit mask
   return ((data[word] & mask))!=0;           // Return the sense of the bit
 }
 

--- a/hotspot/src/share/vm/memory/allocation.cpp
+++ b/hotspot/src/share/vm/memory/allocation.cpp
@@ -538,7 +538,7 @@ void Arena::set_size_in_bytes(size_t size) {
 // Total of all Chunks in arena
 size_t Arena::used() const {
   size_t sum = _chunk->length() - (_max-_hwm); // Size leftover in this Chunk
-  register Chunk *k = _first;
+  REGISTER Chunk *k = _first;
   while( k != _chunk) {         // Whilst have Chunks in a row
     sum += k->length();         // Total size of this Chunk
     k = k->next();              // Bump along to next Chunk

--- a/hotspot/src/share/vm/memory/allocation.cpp
+++ b/hotspot/src/share/vm/memory/allocation.cpp
@@ -538,7 +538,7 @@ void Arena::set_size_in_bytes(size_t size) {
 // Total of all Chunks in arena
 size_t Arena::used() const {
   size_t sum = _chunk->length() - (_max-_hwm); // Size leftover in this Chunk
-  Chunk *k = _first;
+  register Chunk *k = _first;
   while( k != _chunk) {         // Whilst have Chunks in a row
     sum += k->length();         // Total size of this Chunk
     k = k->next();              // Bump along to next Chunk

--- a/hotspot/src/share/vm/opto/mulnode.cpp
+++ b/hotspot/src/share/vm/opto/mulnode.cpp
@@ -46,7 +46,7 @@ uint MulNode::hash() const {
 //------------------------------Identity---------------------------------------
 // Multiplying a one preserves the other argument
 Node *MulNode::Identity( PhaseTransform *phase ) {
-  register const Type *one = mul_id();  // The multiplicative identity
+  REGISTER const Type *one = mul_id();  // The multiplicative identity
   if( phase->type( in(1) )->higher_equal( one ) ) return in(2);
   if( phase->type( in(2) )->higher_equal( one ) ) return in(1);
 

--- a/hotspot/src/share/vm/opto/mulnode.cpp
+++ b/hotspot/src/share/vm/opto/mulnode.cpp
@@ -46,7 +46,7 @@ uint MulNode::hash() const {
 //------------------------------Identity---------------------------------------
 // Multiplying a one preserves the other argument
 Node *MulNode::Identity( PhaseTransform *phase ) {
-  const Type *one = mul_id();  // The multiplicative identity
+  register const Type *one = mul_id();  // The multiplicative identity
   if( phase->type( in(1) )->higher_equal( one ) ) return in(2);
   if( phase->type( in(2) )->higher_equal( one ) ) return in(1);
 

--- a/hotspot/src/share/vm/utilities/globalDefinitions.hpp
+++ b/hotspot/src/share/vm/utilities/globalDefinitions.hpp
@@ -85,6 +85,9 @@
 #ifndef ATTRIBUTE_PRINTF
 #define ATTRIBUTE_PRINTF(fmt, vargs)
 #endif
+#ifndef REGISTER
+#define REGISTER register
+#endif
 
 
 #include "utilities/macros.hpp"

--- a/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
+++ b/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
@@ -348,4 +348,14 @@ inline int wcslen(const jchar* x) { return wcslen((const wchar_t*)x); }
 #define NOINLINE     __attribute__ ((noinline))
 #define ALWAYSINLINE inline __attribute__ ((always_inline))
 
+// register keyword is no longer supported in c++17, but causes issues if removed
+// We define to nothing here and the default define to 'register' is in globalDefinitions.hpp
+// See also:
+// https://github.com/openjdk/jdk8u-dev/pull/11
+// https://bugs.openjdk.org/browse/JDK-8281098
+// https://github.com/corretto/corretto-8/issues/411
+#if defined(__cplusplus) && __cplusplus>=201703L
+#define REGISTER
+#endif
+
 #endif // SHARE_VM_UTILITIES_GLOBALDEFINITIONS_GCC_HPP


### PR DESCRIPTION
Fix for #411 

Also ran tier1/2 on Mac, Linux x64, Linux aarch64 and Alpine.

### How has this been tested?
Build and tested in AL2 with GCC 7.3.1 and AL2022 with GCC 11.

java -XX:NativeMemoryTracking=detail -version did not crash.
