### PR TITLE
Typo: Correct "apline" to "alpine"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ The following issues are addressed in 8.342.07.1
 | Import jdk8u342-b07 | All | Updates Corretto baseline to OpenJDK 8u342-b07 | [jdk8u342-b08](https://github.com/openjdk/jdk8u/releases/tag/jdk8u342-b07)
 | Update CACerts      | All | Pull in the latest CA Certificates from Amazon Linux | [PR #403](https://github.com/corretto/corretto-8/pull/403) |
 | Fix builds on Alpine 3.13 | Alpine Linux 3.13 | Backport [JDK-8263718](https://bugs.openjdk.org/browse/JDK-8263718) to fix builds on alpine-3.13 | [PR #397](https://github.com/corretto/corretto-8/pull/397) |
-| Alpine package missing "provides" variable | Alpine Linux | Add `provides java-jdk` for Corretto apline packages | [Issues #391](https://github.com/corretto/corretto-8/issues/391) |
+| Alpine package missing "provides" variable | Alpine Linux | Add `provides java-jdk` for Corretto alpine packages | [Issues #391](https://github.com/corretto/corretto-8/issues/391) |
 | Update OS detection code to recognize Windows 10/11 | Windows 10/11 | Backport [JDK-8071530](https://bugs.openjdk.org/browse/JDK-8071530) to recognize Windows 10 and [JDK-8274840](https://bugs.openjdk.org/browse/JDK-8274840) to recognize Windows 11 when calling `System.getProperty("os.name")` | [Issues #396](https://github.com/corretto/corretto-8/issues/396) |
 | Migrate pkg builds to productbuild from packages | macOS       | Updates to macos packaging                                                           | [PR #390](https://github.com/corretto/corretto-8/pull/390) |
 | Enable bundled zlib library via Gradle           | macOS       | Updates to use bundled (not the system) version of the zlib library on macOS aarch64 | [PR #404](https://github.com/corretto/corretto-8/pull/404) |


### PR DESCRIPTION
Fixes a typo in the Changelog

Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Fixes a typo in the changelog for Corretto 8, where "alpine" was accidentally spelled "apline"

### Related issues
None

### Motivation and context
I noticed the typo while looking through the changelog, and figured I should submit a PR to fix the typo.

### How has this been tested?
No code change. Correcting a typo.

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only] N/A
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")] N/A


### Additional context
N/A


### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
