### PR TITLE
Fix assert on non-M1 platforms

### DIFF
--- a/hotspot/src/share/vm/runtime/thread.cpp
+++ b/hotspot/src/share/vm/runtime/thread.cpp
@@ -260,7 +260,8 @@ Thread::Thread() {
   omInUseList = NULL ;
   omInUseCount = 0 ;
 
-#ifdef ASSERT
+#if defined(ASSERT) && defined(__APPLE__) && defined(AARCH64)
+
   _visited_for_critical_count = false;
   _wx_init = false;
 #endif
@@ -3925,7 +3926,7 @@ JavaThread* Threads::find_java_thread_from_java_tid(jlong java_tid) {
   // assumption that java tids are globally unique at any given point in time.
   // I.e., there is a global 1-1 mapping between java tids and active JavaThreads.
   JavaThread* java_thread = ThreadService::get_java_thread(java_tid);
-  
+
   // Return directly if java_thread found in _tid_java_map is valid.
   // If java_thread not exist in _tid_java_map or not valid, do a sequential search.
   // The special case is primordial thread (tid=1), which doesn't include an oop,

--- a/hotspot/src/share/vm/runtime/thread.hpp
+++ b/hotspot/src/share/vm/runtime/thread.hpp
@@ -663,7 +663,7 @@ protected:
   static void muxRelease  (volatile intptr_t * Lock) ;
 
 private:
-#ifdef ASSERT
+#if defined(ASSERT) && defined(__APPLE__) && defined(AARCH64)
   bool _wx_init;
   WXMode _wx_state;
   static inline void verify_wx_init(WXMode state) {
@@ -1997,7 +1997,7 @@ class Threads: AllStatic {
 #endif
 
  private:
-  // Used by find_java_thread_from_tid 
+  // Used by find_java_thread_from_tid
   static bool is_valid_java_thread(jlong java_tid, JavaThread* jt);
 
  public:


### PR DESCRIPTION
Fixing fastdebug issue happening on Windows builds. 

This code shouldn't be executed anywhere but M1 builds based on JDK11 code where WX initialization only happens within `#ifdef` blocks:
https://github.com/openjdk/jdk11u-dev/blob/0aa5f75d7af2f04c93fd066e17e624f92f4f998f/src/hotspot/share/prims/jni.cpp#L4059
https://github.com/openjdk/jdk11u-dev/blob/684f12e7fd0f939ccc133aec46ed3fb7d24d5cc8/src/hotspot/share/runtime/thread.hpp#L757-L764

Passed internal fastdebug builds and testing