### PR TITLE
Revert "8274864: Remove Amman/Cairo hacks in ZoneInfoFile"

### DIFF
--- a/jdk/src/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/jdk/src/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -608,6 +608,33 @@ public final class ZoneInfoFile {
                 params[9] = toSTZTime[endRule.timeDefinition];
                 dstSavings = (startRule.offsetAfter - startRule.offsetBefore) * 1000;
 
+                // Note: known mismatching -> Asia/Amman
+                // ZoneInfo :      startDayOfWeek=5     <= Thursday
+                //                 startTime=86400000   <= 24 hours
+                // This:           startDayOfWeek=6
+                //                 startTime=0
+                // Similar workaround needs to be applied to Africa/Cairo and
+                // its endDayOfWeek and endTime
+                // Below is the workarounds, it probably slows down everyone a little
+                if (params[2] == 6 && params[3] == 0 &&
+                    (zoneId.equals("Asia/Amman"))) {
+                    params[2] = 5;
+                    params[3] = 86400000;
+                }
+                // Additional check for startDayOfWeek=6 and starTime=86400000
+                // is needed for Asia/Amman;
+                if (params[2] == 7 && params[3] == 0 &&
+                     (zoneId.equals("Asia/Amman"))) {
+                    params[2] = 6;        // Friday
+                    params[3] = 86400000; // 24h
+                }
+                //endDayOfWeek and endTime workaround
+                if (params[7] == 6 && params[8] == 0 &&
+                    (zoneId.equals("Africa/Cairo"))) {
+                    params[7] = 5;
+                    params[8] = 86400000;
+                }
+
                 // Note: known mismatching -> Africa/Cairo
                 // ZoneInfo :      startDayOfWeek=5     <= Thursday
                 //                 startTime=86400000   <= 24:00


### PR DESCRIPTION
This reverts commit f62fa388

As it might be not safe to apply "8274864: Remove Amman/Cairo hacks in ZoneInfoFile" to 8 it is better to revert the fix.
