### PR TITLE
Backport/reimplement AL RPM changes

### DIFF
--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -44,6 +44,7 @@ task inflateRpmSpec(type: Copy) {
         }
         filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [ debug_level: correttoDebugLevel])
         filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [ experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}" ])
+        filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [ additional_configure_options: project.findProperty("corretto.additional_configure_options") ?: "%{nil}"])
     }
     into buildRoot
 }

--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -43,6 +43,7 @@ task inflateRpmSpec(type: Copy) {
             prop -> filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [ (prop.key): String.valueOf(prop.value)])
         }
         filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [ debug_level: correttoDebugLevel])
+        filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [ experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}" ])
     }
     into buildRoot
 }

--- a/installers/linux/al2/spec/java-1.8.0-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-1.8.0-amazon-corretto.spec.template
@@ -24,6 +24,7 @@
 %global corretto_revision @revision@
 %global java_home %{_jvmdir}/%{name}.%{_arch}
 %global experimental_feature     @experimental_feature@
+%global additional_configure_options     @additional_configure_options@
 
 # The experimental_feature macro gets set to %nil by the template, but that is still defined and
 # the spec doesn't have a quick is not nil check, just define/not defined, this makes it easier to
@@ -32,6 +33,9 @@
 %undefine experimental_feature
 %endif
 
+%if 0%{?additional_configure_options:1} == 1 && "%{additional_configure_options}" == "%{nil}"
+%undefine additional_configure_options
+%endif
 # Higher numbers win for the alternatives program.
 # AL2 has chosen java-1.7.0-openjdk to be default (priority 17000)
 # with java-1.8.0-openjdk as second (priority 1800)
@@ -179,12 +183,15 @@ Amazon Corretto's packaging of the OpenJDK 8 code.
 
 %build
 bash ./configure \
+%if 0%{?additional_configure_options:1}
+    %{additional_configure_options} \
+%endif
   --with-zlib=system \
   --with-giflib=system \
   --with-update-version="%{java_update}" \
   --with-build-number="%{buildver}" \
   --with-corretto-revision="%{corretto_revision}" \
-  --with-milestone="fcs" \
+  --with-milestone=%{?experimental_feature:%experimental_feature}%{!?experimental_feature:fcs} \
   --disable-debug-symbols \
   --disable-zip-debug-info \
   --enable-jfr \

--- a/installers/linux/al2/spec/java-1.8.0-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-1.8.0-amazon-corretto.spec.template
@@ -23,6 +23,14 @@
 %global buildver b@build@
 %global corretto_revision @revision@
 %global java_home %{_jvmdir}/%{name}.%{_arch}
+%global experimental_feature     @experimental_feature@
+
+# The experimental_feature macro gets set to %nil by the template, but that is still defined and
+# the spec doesn't have a quick is not nil check, just define/not defined, this makes it easier to
+# work with
+%if 0%{?experimental_feature:1} && "%{experimental_feature}" == "%{nil}"
+%undefine experimental_feature
+%endif
 
 # Higher numbers win for the alternatives program.
 # AL2 has chosen java-1.7.0-openjdk to be default (priority 17000)
@@ -72,7 +80,7 @@
 %endif
 
 Summary: Amazon Corretto runtime environment
-Name: java-1.8.0-amazon-corretto
+Name: java-1.8.0-amazon-corretto%{?experimental_feature:-%{experimental_feature}}
 # Matches the 'full version' from Java's release notes:
 # https://www.oracle.com/technetwork/java/javase/8u181-relnotes-4479407.html
 # Eg: 1.8.0_181-b13
@@ -83,7 +91,7 @@ Group: Development/Languages
 License: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib.
 Vendor: Amazon
 Url: https://github.com/corretto/corretto-8
-Source0: %{name}.tar.gz
+Source0: java-1.8.0-amazon-corretto.tar.gz
 ExclusiveArch: x86_64 aarch64
 
 # jpackage-utils/javapackages-filesystem is required for both build and runtime.


### PR DESCRIPTION
This has the same effect at the patches from 17 for experimental features and the configure flags, but 8 is different enough it is essentially re-implementation.

I ran some local builds with experimental feature and addition configure and it worked as as expected.