### PR TITLE
[macosx] Undecorated Frame does not Iconify when set to

### DIFF
--- a/jdk/src/macosx/native/sun/awt/AWTWindow.m
+++ b/jdk/src/macosx/native/sun/awt/AWTWindow.m
@@ -203,13 +203,13 @@ AWT_NS_WINDOW_IMPLEMENTATION
     if (IS(styleBits, DECORATED)) {
         type |= NSTitledWindowMask;
         if (IS(styleBits, CLOSEABLE))            type |= NSClosableWindowMask;
-        if (IS(styleBits, MINIMIZABLE))          type |= NSMiniaturizableWindowMask;
         if (IS(styleBits, RESIZABLE))            type |= NSResizableWindowMask;
         if (IS(styleBits, FULL_WINDOW_CONTENT))  type |= NSFullSizeContentViewWindowMask;
     } else {
         type |= NSBorderlessWindowMask;
     }
 
+    if (IS(styleBits, MINIMIZABLE))   type |= NSMiniaturizableWindowMask;
     if (IS(styleBits, TEXTURED))      type |= NSTexturedBackgroundWindowMask;
     if (IS(styleBits, UNIFIED))       type |= NSUnifiedTitleAndToolbarWindowMask;
     if (IS(styleBits, UTILITY))       type |= NSUtilityWindowMask;
@@ -320,7 +320,7 @@ AWT_ASSERT_APPKIT_THREAD;
     [self setPropertiesForStyleBits:styleBits mask:MASK(_METHOD_PROP_BITMASK)];
 
     if (IS(self.styleBits, IS_POPUP)) {
-        [self.nsWindow setCollectionBehavior:(1 << 8) /*NSWindowCollectionBehaviorFullScreenAuxiliary*/]; 
+        [self.nsWindow setCollectionBehavior:(1 << 8) /*NSWindowCollectionBehaviorFullScreenAuxiliary*/];
     }
 
     return self;
@@ -469,7 +469,7 @@ AWT_ASSERT_APPKIT_THREAD;
 // Tests whether window is blocked by modal dialog/window
 - (BOOL) isBlocked {
     BOOL isBlocked = NO;
-    
+
     JNIEnv *env = [ThreadUtilities getJNIEnv];
     jobject platformWindow = [self.javaPlatformWindow jObjectWithEnv:env];
     if (platformWindow != NULL) {
@@ -477,7 +477,7 @@ AWT_ASSERT_APPKIT_THREAD;
         isBlocked = JNFCallBooleanMethod(env, platformWindow, jm_isBlocked) == JNI_TRUE ? YES : NO;
         (*env)->DeleteLocalRef(env, platformWindow);
     }
-    
+
     return isBlocked;
 }
 
@@ -498,18 +498,18 @@ AWT_ASSERT_APPKIT_THREAD;
 // Tests whether the corresponding Java platform window is visible or not
 + (BOOL) isJavaPlatformWindowVisible:(NSWindow *)window {
     BOOL isVisible = NO;
-    
+
     if ([AWTWindow isAWTWindow:window] && [window delegate] != nil) {
         AWTWindow *awtWindow = (AWTWindow *)[window delegate];
         [AWTToolkit eventCountPlusPlus];
-        
+
         JNIEnv *env = [ThreadUtilities getJNIEnv];
         jobject platformWindow = [awtWindow.javaPlatformWindow jObjectWithEnv:env];
         if (platformWindow != NULL) {
             static JNF_MEMBER_CACHE(jm_isVisible, jc_CPlatformWindow, "isVisible", "()Z");
             isVisible = JNFCallBooleanMethod(env, platformWindow, jm_isVisible) == JNI_TRUE ? YES : NO;
             (*env)->DeleteLocalRef(env, platformWindow);
-            
+
         }
     }
     return isVisible;
@@ -1411,7 +1411,7 @@ JNF_COCOA_ENTER(env);
     } else {
         [JNFException raise:env as:kIllegalArgumentException reason:"unknown event type"];
     }
-    
+
 JNF_COCOA_EXIT(env);
 }
 
@@ -1521,7 +1521,7 @@ JNF_COCOA_ENTER(env);
 
         if (CGDisplayRelease(aID) == kCGErrorSuccess) {
             NSUInteger styleMask = [AWTWindow styleMaskForStyleBits:window.styleBits];
-            [nsWindow setStyleMask:styleMask]; 
+            [nsWindow setStyleMask:styleMask];
             [nsWindow setLevel: window.preFullScreenLevel];
 
             // GraphicsDevice takes care of restoring pre full screen bounds

--- a/jdk/test/java/awt/Frame/NormalToIconified/NormalToIconifiedTest.java
+++ b/jdk/test/java/awt/Frame/NormalToIconified/NormalToIconifiedTest.java
@@ -40,12 +40,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import test.java.awt.regtesthelpers.Util;
 
 public class NormalToIconifiedTest {
-    private static final AtomicBoolean listenerNotified = new AtomicBoolean(false);
 
     public static void main(String[] args) {
+        test(false);
+        test(true);
+    }
+
+    private static void test(final boolean undecorated) {
+        AtomicBoolean listenerNotified = new AtomicBoolean(false);
+
         Robot robot = Util.createRobot();
 
         Frame testFrame = new Frame("Test Frame");
+        testFrame.setUndecorated(undecorated);
         testFrame.setSize(200, 200);
         testFrame.addWindowStateListener(new WindowStateListener() {
             @Override
@@ -102,4 +109,3 @@ public class NormalToIconifiedTest {
         }
     }
 }
-


### PR DESCRIPTION
Taken from https://bugs.openjdk.org/browse/JDK-8214046 with the patch from https://hg.openjdk.org/jdk/jdk/rev/769dbf384c44

### Description

Manually and programmatically trying to minimize/iconify a Frame von MacOS does not work, when the Frame is undecorated.

### Related issues

See https://bugs.openjdk.org/browse/JDK-8214046

### Motivation and context

We're migrating from Oracle Java to Amazon Corretto and running into this issue on MacOS.

### How has this been tested?

Manually. The issue is also reproducible as shown in the provided test.

### Platform information
    Works on OS: MacOS (Ventura 13.4.1, but we assume that the MacOS version does not matter)
    Applies to version Amazon Corretto 1.8.0_372

### Additional context


### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

I have to mention that the provided patch is not written by myself, but taken from the OpenJDK sources. If you have other means of taking sources from the upstream OpenJDK sources, please do so and feel free to close this pull request. Thanks!
