### PR TITLE
Windows: remove --with-toolchain-version --with-ucrt-dll-dir --with-m…

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -35,10 +35,7 @@ task configureBuild(type: Exec) {
     // Platform specific flags
     def command = ['bash', 'configure',
             "--with-boot-jdk=${project.getProperty('bootjdk_dir')}",
-            "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/msvcr120.dll",
-            "--with-msvcp-dll=${project.getProperty('msvcp_dir')}/msvcp120.dll",
-            "--with-freetype=${project.getProperty('freetype_dir')}",
-            "--with-toolchain-version=2013"]
+            "--with-freetype=${project.getProperty('freetype_dir')}"]
     // Common flags
     command += project.correttoCommonFlags
     commandLine command.flatten()


### PR DESCRIPTION
Configure is able to get dll's needed automatically from VS.
There is still option to specify these via [corretto.extra_config](https://github.com/corretto/corretto-jdk/blob/develop/build.gradle#L136C52-L136C73) in case customization is needed.

Checked by building with VS 2013, VS 2019.