### PR TITLE
Fix GA for Corretto

### DIFF
--- a/hotspot/src/share/vm/memory/heapInspection.hpp
+++ b/hotspot/src/share/vm/memory/heapInspection.hpp
@@ -367,7 +367,7 @@ class HeapInspection : public StackObj {
       _csv_format(csv_format), _print_help(print_help),
       _print_class_stats(print_class_stats), _columns(columns) {}
   void heap_inspection(outputStream* st) NOT_SERVICES_RETURN;
-  size_t populate_table(KlassInfoTable* cit, BoolObjectClosure* filter = NULL) NOT_SERVICES_RETURN;
+  size_t populate_table(KlassInfoTable* cit, BoolObjectClosure* filter = NULL) NOT_SERVICES_RETURN_(0);
   static void find_instances_at_safepoint(Klass* k, GrowableArray<oop>* result) NOT_SERVICES_RETURN;
  private:
   void iterate_over_heap(KlassInfoTable* cit, BoolObjectClosure* filter = NULL);

--- a/hotspot/src/share/vm/memory/metaspaceShared.hpp
+++ b/hotspot/src/share/vm/memory/metaspaceShared.hpp
@@ -93,7 +93,7 @@ class MetaspaceShared : AllStatic {
   static void preload_and_dump(TRAPS) NOT_CDS_RETURN;
   static int preload_and_dump(const char * class_list_path,
                               GrowableArray<Klass*>* class_promote_order,
-                              TRAPS) NOT_CDS_RETURN;
+                              TRAPS) NOT_CDS_RETURN_(0);
 
   static ReservedSpace* shared_rs() {
     CDS_ONLY(return _shared_rs);


### PR DESCRIPTION
Part of the https://bugs.openjdk.org/browse/JDK-8062808 was lost in corretto-8.