### PR TITLE
generated-configure.sh: line 27701: 9: No such file or directory

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4462,7 +4462,7 @@ VS_TOOLSET_SUPPORTED_2022=true
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1694011184
+DATE_WHEN_GENERATED=1705477480
 
 ###############################################################################
 #
@@ -27698,8 +27698,8 @@ fi
     fi
 
     # Fail-fast: verify we're building on a supported Xcode version
-    if test "${XCODE_MAJOR_VERSION}" != "6" -o "${XCODE_MAJOR_VERSION}" < "9" ; then
-      as_fn_error $? "Xcode 6, or 9+ is required to build JDK 8, the version found was $XCODE_VERSION. Use --with-xcode-path to specify the location of Xcode or make Xcode active by using xcode-select." "$LINENO" 5
+    if test "${XCODE_MAJOR_VERSION}" -ne 6 -a "${XCODE_MAJOR_VERSION}" -lt 9 ; then
+      as_fn_error $? "Xcode 6, or 9+ is required to build JDK 8, the version found was $XCODE_MAJOR_VERSION. Use --with-xcode-path to specify the location of Xcode or make Xcode active by using xcode-select." "$LINENO" 5
     fi
 
     # Some versions of Xcode command line tools install gcc and g++ as symlinks to
@@ -57910,3 +57910,4 @@ fi
       printf "\n"
     fi
   fi
+

--- a/common/autoconf/toolchain.m4
+++ b/common/autoconf/toolchain.m4
@@ -294,8 +294,8 @@ AC_DEFUN_ONCE([TOOLCHAIN_PRE_DETECTION],
     fi
 
     # Fail-fast: verify we're building on a supported Xcode version
-    if test "${XCODE_MAJOR_VERSION}" != "6" -o "${XCODE_MAJOR_VERSION}" < "9" ; then
-      AC_MSG_ERROR([Xcode 6, or 9+ is required to build JDK 8, the version found was $XCODE_VERSION. Use --with-xcode-path to specify the location of Xcode or make Xcode active by using xcode-select.])
+    if test "${XCODE_MAJOR_VERSION}" -ne 6 -a "${XCODE_MAJOR_VERSION}" -lt 9 ; then
+      AC_MSG_ERROR([Xcode 6, or 9+ is required to build JDK 8, the version found was $XCODE_MAJOR_VERSION. Use --with-xcode-path to specify the location of Xcode or make Xcode active by using xcode-select.])
     fi
 
     # Some versions of Xcode command line tools install gcc and g++ as symlinks to


### PR DESCRIPTION
This is the fix for the next warning produced by the `./configure` on macOS:
>checking for xcodebuild... /usr/bin/xcodebuild
...../corretto/corretto-8/common/autoconf/generated-configure.sh: line 27701: 9: No such file or directory
checking Determining Xcode SDK path... /