### PR TITLE
Fix formatting in changelog for 8.402.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ in the Amazon Corretto FAQ for supported platforms
 
 The following issues are addressed in 8.402.07.1:
 
-| Issue Name                         | Platform                                     | Description                                    | Link                                                                                            |
-|------------------------------------|----------------------------------------------|------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| Import jdk8u402-b06                | All | Updates Corretto baseline to OpenJDK 8u402-b06 | [jdk8u402-b06](https://github.com/openjdk/jdk8u/releases/tag/jdk8u402-b06)                      |
-| (tz) Update Timezone Data to 2023d | All | Update Timezone Data to 2023d                  | [483](https://github.com/corretto/corretto-8/commit/719dd760e071e7fd2ba1be552af5502f422259b9)   |
-| NPE in PKCS7.parseOldSignedData    | All | fixes exception PKCS7.parseOldSignedDat        | [JDK-8315042] (https://bugs.openjdk.org/browse/JDK-8315042)                                     |
-| Disable build-ids in AL RPMs       | AL2023  | Build-ids can conflict across versions     | N/A                                                                                             |
+| Issue Name                         | Platform                                     | Description                                    | Link                                                                                           |
+|------------------------------------|----------------------------------------------|------------------------------------------------|------------------------------------------------------------------------------------------------|
+| Import jdk8u402-b06                | All | Updates Corretto baseline to OpenJDK 8u402-b06 | [jdk8u402-b06](https://github.com/openjdk/jdk8u/releases/tag/jdk8u402-b06)                     |
+| (tz) Update Timezone Data to 2023d | All | Update Timezone Data to 2023d                  | [483](https://github.com/corretto/corretto-8/commit/719dd760e071e7fd2ba1be552af5502f422259b9)  |
+| NPE in PKCS7.parseOldSignedData    | All | fixes exception PKCS7.parseOldSignedDat        | [JDK-8315042](https://bugs.openjdk.org/browse/JDK-8315042)                                     |
+| Disable build-ids in AL RPMs       | AL2023  | Build-ids can conflict across versions     | N/A                                                                                            |
 | Add __APPLE__ to ADCLFlags         | MacOS aarch64 | Add __APPLE__ define and exclude R18 from usable registers | N/A                                                                       |
 | On the latest macOS+XCode the Robot API may report wrong colors | MacOS all | Xcode 14+ and MacOS 13+ cause some tests to fail | [JDK-8298887](https://bugs.openjdk.org/browse/JDK-8298887) |
 | macOS Monterey does not have the font Times needed by Serif | MacOS all | macOS Monterey does not have the font Times needed by Serif | [JDK-8273358](https://bugs.openjdk.org/browse/JDK-8273358) |
@@ -57,12 +57,12 @@ in the Amazon Corretto FAQ for supported platforms
 
 The following issues are addressed in 8.402.06.1:
 
-| Issue Name                         | Platform                                     | Description                                    | Link                                                                                            |
-|------------------------------------|----------------------------------------------|------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| Import jdk8u402-b06                | All | Updates Corretto baseline to OpenJDK 8u402-b06 | [jdk8u402-b05](https://github.com/openjdk/jdk8u/releases/tag/jdk8u402-b06)                      |
-| (tz) Update Timezone Data to 2023d | All | Update Timezone Data to 2023d                  | [483](https://github.com/corretto/corretto-8/commit/719dd760e071e7fd2ba1be552af5502f422259b9)   |
-| NPE in PKCS7.parseOldSignedData    | All | fixes exception PKCS7.parseOldSignedDat        | [JDK-8315042] (https://bugs.openjdk.org/browse/JDK-8315042)                                   |
-| Disable build-ids in AL RPMs       | AL2023  | Build-ids can conflict across versions     | N/A                                                                                             |
+| Issue Name                         | Platform                                     | Description                                    | Link                                                                                           |
+|------------------------------------|----------------------------------------------|------------------------------------------------|------------------------------------------------------------------------------------------------|
+| Import jdk8u402-b06                | All | Updates Corretto baseline to OpenJDK 8u402-b06 | [jdk8u402-b05](https://github.com/openjdk/jdk8u/releases/tag/jdk8u402-b06)                     |
+| (tz) Update Timezone Data to 2023d | All | Update Timezone Data to 2023d                  | [483](https://github.com/corretto/corretto-8/commit/719dd760e071e7fd2ba1be552af5502f422259b9)  |
+| NPE in PKCS7.parseOldSignedData    | All | fixes exception PKCS7.parseOldSignedDat        | [JDK-8315042](https://bugs.openjdk.org/browse/JDK-8315042)                                   |
+| Disable build-ids in AL RPMs       | AL2023  | Build-ids can conflict across versions     | N/A                                                                                            |
 
 
 The following CVEs are addressed in 8.402.06.1:


### PR DESCRIPTION
The formatting of some links are updated.
The current document:
  https://github.com/corretto/corretto-8/blob/release-8.402.07.1/CHANGELOG.md
Thee new document
  https://github.com/mrserb/corretto-8/blob/release-8.402.07.1/CHANGELOG.md

Check the link for "fixes exception PKCS7.parseOldSignedDat"