### PR TITLE
Correct baseline for Corretto 8.402.06.1 is jdk8u402-b06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ The following issues are addressed in 8.402.06.1:
 
 | Issue Name                         | Platform                                     | Description                                    | Link                                                                                           |
 |------------------------------------|----------------------------------------------|------------------------------------------------|------------------------------------------------------------------------------------------------|
-| Import jdk8u402-b06                | All | Updates Corretto baseline to OpenJDK 8u402-b06 | [jdk8u402-b05](https://github.com/openjdk/jdk8u/releases/tag/jdk8u402-b06)                     |
+| Import jdk8u402-b06                | All | Updates Corretto baseline to OpenJDK 8u402-b06 | [jdk8u402-b06](https://github.com/openjdk/jdk8u/releases/tag/jdk8u402-b06)                     |
 | (tz) Update Timezone Data to 2023d | All | Update Timezone Data to 2023d                  | [483](https://github.com/corretto/corretto-8/commit/719dd760e071e7fd2ba1be552af5502f422259b9)  |
 | NPE in PKCS7.parseOldSignedData    | All | fixes exception PKCS7.parseOldSignedDat        | [JDK-8315042](https://bugs.openjdk.org/browse/JDK-8315042)                                   |
 | Disable build-ids in AL RPMs       | AL2023  | Build-ids can conflict across versions     | N/A                                                                                            |


### PR DESCRIPTION
The typo for the latest release is fixed. Correct baseline for Corretto 8.402.06.1 is jdk8u402-b06