### PR TITLE
AL: Add Provides java-headless

### DIFF
--- a/installers/linux/al2/spec/java-1.8.0-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-1.8.0-amazon-corretto.spec.template
@@ -170,6 +170,7 @@ Requires: log4j-cve-2021-44228-cve-mitigations
 
 Provides: java = %{epoch}:%{javaver}
 Provides: java-%{javaver} = %{epoch}:%{version}-%{release}
+Provides: java-headless = %{epoch}:%{javaver}
 
 %description
 Amazon Corretto's packaging of the runtime core elements of the OpenJDK 8 code.


### PR DESCRIPTION
Built and tested in AL2023 internal pipelines. This will allow Corretto8 to be used as a dependency for some system packages that require headless package only.