### PR TITLE
Restore JDK-8256618

### DIFF
--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -5216,7 +5216,7 @@ jint os::init_2(void)
 
   Linux::capture_initial_stack(JavaThread::stack_size_at_create());
 
-#if defined(IA32)
+#if defined(IA32) && !defined(ZERO)
   workaround_expand_exec_shield_cs_limit();
 #endif
 


### PR DESCRIPTION
This is a request to restore the patch for [JDK-8256618](https://hg.openjdk.org/jdk8u/jdk8u/hotspot/rev/3a93682b0b44)

It was reverted during the merge [here](https://github.com/corretto/corretto-8/commit/7b6d16bf467d537847df9c012a7d1596f46de784#diff-8c8bdcb8d54cff1b21154dc6bb692347e7a7d7aeae8c612000c0c6f87fbe0d63L5182).