### PR TITLE
Fix jfx build logic

### DIFF
--- a/javafx/build.gradle
+++ b/javafx/build.gradle
@@ -74,13 +74,6 @@ task patchJfx {
             ant.patch(patchfile: f, 
                     dir: "$buildRoot/rt-${openJfxVersion.getProperty('tag')}", strip: "1", failonerror: true) 
         }
-        fileTree("patches/${OS_NAME}").matching {
-            include '*.patch'
-        }.files.sort().each { f ->
-            ant.patch(patchfile: f, 
-                    dir: "$buildRoot/rt-${openJfxVersion.getProperty('tag')}", strip: "1", failonerror: true) 
-        }
-
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             fileTree("patches/windows").matching {
                 include '*.patch'


### PR DESCRIPTION
Forgot to remove incorrect build logic in previous commit 2b0d1569, which caused patching jfx twice. Removing them here.

Ran with internal pipelines for win, mac & linux