### PR TITLE
8328809: [8u] Problem list some CA tests

### DIFF
--- a/jdk/test/ProblemList.txt
+++ b/jdk/test/ProblemList.txt
@@ -383,3 +383,15 @@ sun/tools/jps/TestJpsJarRelative.java				generic-all
 
 sample/mergesort/MergeSortTest.java				8178912 generic-all
 sample/chatserver/ChatTest.java					8178912 generic-all
+
+############################################################################
+
+# cacerts tests
+
+############################################################################
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#globalsigneccrootcar4  8328825 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootcar1            8328825 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootcar2            8328825 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootecccar3         8328825 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#gtsrootecccar4         8328825 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java                       8314509 generic-all


### PR DESCRIPTION
This is request to port the https://bugs.openjdk.org/browse/JDK-8328809 into the upcoming release of correto-8.