### PR TITLE
8203691: Test /runtime/containers/cgroup/PlainRead.java fails

### DIFF
--- a/hotspot/test/runtime/containers/cgroup/PlainRead.java
+++ b/hotspot/test/runtime/containers/cgroup/PlainRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,9 +73,6 @@ public class PlainRead {
         if (wb.isContainerized()) {
             System.out.println("Inside a cgroup, testing...");
             isContainer(output);
-        } else {
-            System.out.println("Not in a cgroup, testing...");
-            isNotContainer(output);
         }
     }
 }


### PR DESCRIPTION
This is request to port the https://bugs.openjdk.org/browse/JDK-8203691 into the upcoming release of correto-8.
Note: I have requested backport in upstream as well.
