### PR TITLE
Add /test/lib path to @library in sun/security/krb5/auto/ReplayCacheTestProc.java

### DIFF
--- a/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java
+++ b/jdk/test/sun/security/krb5/auto/ReplayCacheTestProc.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 7152176 8168518
  * @summary More krb5 tests
- * @library ../../../../java/security/testlibrary/
+ * @library ../../../../java/security/testlibrary/ /test/lib
  * @compile -XDignore.symbol.file ReplayCacheTestProc.java
  * @run main/othervm/timeout=300 -Dsun.net.spi.nameservice.provider.1=ns,mock ReplayCacheTestProc
  */


### PR DESCRIPTION
This is a backport of https://github.com/openjdk/jdk8u-dev/pull/478.

https://bugs.openjdk.org/browse/JDK-8329544