### PR TITLE
Restore the default behavior of UnixNativeDispatcher.c.

### DIFF
--- a/jdk/src/solaris/native/sun/nio/fs/UnixNativeDispatcher.c
+++ b/jdk/src/solaris/native/sun/nio/fs/UnixNativeDispatcher.c
@@ -466,6 +466,12 @@ static void prepAttributes(JNIEnv* env, struct stat64* buf, jobject attrs) {
 #ifdef _DARWIN_FEATURE_64_BIT_INODE
     (*env)->SetLongField(env, attrs, attrs_st_birthtime_sec, (jlong)buf->st_birthtime);
 #endif
+
+#if (_POSIX_C_SOURCE >= 200809L) || defined(__solaris__)
+    (*env)->SetLongField(env, attrs, attrs_st_atime_nsec, (jlong)buf->st_atim.tv_nsec);
+    (*env)->SetLongField(env, attrs, attrs_st_mtime_nsec, (jlong)buf->st_mtim.tv_nsec);
+    (*env)->SetLongField(env, attrs, attrs_st_ctime_nsec, (jlong)buf->st_ctim.tv_nsec);
+#endif
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
Implementation is aligned with the upstream, see: https://github.com/openjdk/jdk/commit/69b0c6aad4b42c38615e81542d49acb15ce48781