### PR TITLE
Remove clean target in Windows builds

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -66,7 +66,7 @@ task executeBuild(type: Exec) {
     dependsOn configureBuild
     workingDir "$buildRoot"
 
-    commandLine 'make', 'clean', 'images'
+    commandLine 'make', 'images'
 }
 
 task applyJavafxOverlay() {


### PR DESCRIPTION
`clean` target in Windows builds caused issues and is unnecessary when building.
