### PR TITLE
8318696: Do not use LFS64 symbols on Linux

### DIFF
--- a/hotspot/src/os/linux/vm/attachListener_linux.cpp
+++ b/hotspot/src/os/linux/vm/attachListener_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -446,14 +446,14 @@ AttachOperation* AttachListener::dequeue() {
 
 void AttachListener::vm_start() {
   char fn[UNIX_PATH_MAX];
-  struct stat64 st;
+  struct stat st;
   int ret;
 
   int n = snprintf(fn, UNIX_PATH_MAX, "%s/.java_pid%d",
            os::get_temp_directory(), os::current_process_id());
   assert(n < (int)UNIX_PATH_MAX, "java_pid file name buffer overflow");
 
-  RESTARTABLE(::stat64(fn, &st), ret);
+  RESTARTABLE(::stat(fn, &st), ret);
   if (ret == 0) {
     ret = ::unlink(fn);
     if (ret == -1) {
@@ -480,8 +480,8 @@ int AttachListener::pd_init() {
 
 bool AttachListener::check_socket_file() {
   int ret;
-  struct stat64 st;
-  ret = stat64(LinuxAttachListener::path(), &st);
+  struct stat st;
+  ret = stat(LinuxAttachListener::path(), &st);
   if (ret == -1) { // need to restart attach listener.
     debug_only(warning("Socket file %s does not exist - Restart Attach Listener",
                       LinuxAttachListener::path()));
@@ -521,12 +521,12 @@ bool AttachListener::is_init_trigger() {
   char fn[PATH_MAX+1];
   sprintf(fn, ".attach_pid%d", os::current_process_id());
   int ret;
-  struct stat64 st;
-  RESTARTABLE(::stat64(fn, &st), ret);
+  struct stat st;
+  RESTARTABLE(::stat(fn, &st), ret);
   if (ret == -1) {
     snprintf(fn, sizeof(fn), "%s/.attach_pid%d",
              os::get_temp_directory(), os::current_process_id());
-    RESTARTABLE(::stat64(fn, &st), ret);
+    RESTARTABLE(::stat(fn, &st), ret);
   }
   if (ret == 0) {
     // simple check to avoid starting the attach mechanism when

--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -5613,14 +5613,14 @@ int os::open(const char *path, int oflag, int mode) {
   int o_delete = (oflag & O_DELETE);
   oflag = oflag & ~O_DELETE;
 
-  fd = ::open64(path, oflag, mode);
+  fd = ::open(path, oflag, mode);
   if (fd == -1) return -1;
 
   //If the open succeeded, the file might still be a directory
   {
-    struct stat64 buf64;
-    int ret = ::fstat64(fd, &buf64);
-    int st_mode = buf64.st_mode;
+    struct stat buf;
+    int ret = ::fstat(fd, &buf);
+    int st_mode = buf.st_mode;
 
     if (ret != -1) {
       if ((st_mode & S_IFMT) == S_IFDIR) {
@@ -5677,17 +5677,17 @@ int os::create_binary_file(const char* path, bool rewrite_existing) {
   if (!rewrite_existing) {
     oflags |= O_EXCL;
   }
-  return ::open64(path, oflags, S_IREAD | S_IWRITE);
+  return ::open(path, oflags, S_IREAD | S_IWRITE);
 }
 
 // return current position of file pointer
 jlong os::current_file_offset(int fd) {
-  return (jlong)::lseek64(fd, (off64_t)0, SEEK_CUR);
+  return (jlong)::lseek(fd, (off_t)0, SEEK_CUR);
 }
 
 // move file pointer to the specified offset
 jlong os::seek_to_file_offset(int fd, jlong offset) {
-  return (jlong)::lseek64(fd, (off64_t)offset, SEEK_SET);
+  return (jlong)::lseek(fd, (off_t)offset, SEEK_SET);
 }
 
 // This code originates from JDK's sysAvailable
@@ -5696,10 +5696,10 @@ jlong os::seek_to_file_offset(int fd, jlong offset) {
 int os::available(int fd, jlong *bytes) {
   jlong cur, end;
   int mode;
-  struct stat64 buf64;
+  struct stat buf;
 
-  if (::fstat64(fd, &buf64) >= 0) {
-    mode = buf64.st_mode;
+  if (::fstat(fd, &buf) >= 0) {
+    mode = buf.st_mode;
     if (S_ISCHR(mode) || S_ISFIFO(mode) || S_ISSOCK(mode)) {
       /*
       * XXX: is the following call interruptible? If so, this might
@@ -5713,11 +5713,11 @@ int os::available(int fd, jlong *bytes) {
       }
     }
   }
-  if ((cur = ::lseek64(fd, 0L, SEEK_CUR)) == -1) {
+  if ((cur = ::lseek(fd, 0L, SEEK_CUR)) == -1) {
     return 0;
-  } else if ((end = ::lseek64(fd, 0L, SEEK_END)) == -1) {
+  } else if ((end = ::lseek(fd, 0L, SEEK_END)) == -1) {
     return 0;
-  } else if (::lseek64(fd, cur, SEEK_SET) == -1) {
+  } else if (::lseek(fd, cur, SEEK_SET) == -1) {
     return 0;
   }
   *bytes = end - cur;

--- a/hotspot/src/os/linux/vm/os_linux.inline.hpp
+++ b/hotspot/src/os/linux/vm/os_linux.inline.hpp
@@ -88,7 +88,7 @@ inline void os::dll_unload(void *lib) {
 inline const int os::default_file_open_flags() { return 0;}
 
 inline jlong os::lseek(int fd, jlong offset, int whence) {
-  return (jlong) ::lseek64(fd, offset, whence);
+  return (jlong) ::lseek(fd, offset, whence);
 }
 
 inline int os::fsync(int fd) {
@@ -100,7 +100,7 @@ inline char* os::native_path(char *path) {
 }
 
 inline int os::ftruncate(int fd, jlong length) {
-  return ::ftruncate64(fd, length);
+  return ::ftruncate(fd, length);
 }
 
 // macros for restartable system calls


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Backport to remove LFS64 symbols, e.g. replace lseek64 with lseek, to unblock alpine builds on 3.19.
Not clean, some code was moved into different files. Older build system makes it different to set the c flag `-D_FILE_OFFSET_BITS=64` for hotspot build, which this backport is missing. This only affects linux x86 architectures, but GHA testing has not shown any new failures in that platform. Although that platform is not supported, it may be worth looking into more.

### Related issues
PR for 11: https://github.com/corretto/corretto-11/pull/390
https://bugs.openjdk.org/browse/JDK-8318696

### Motivation and context
See https://github.com/corretto/corretto-11/pull/390

### How has this been tested?
Builds on alpine, tier1 GHA tests show no new failures. Builds and passing jck tests on macos aarch64, Linux x64 and aarch64

### Platform information
    Works on OS: alpine x64, mac aarch64, linux x64 and aarch64
    Applies to version: build 1.8.0_462-b01


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
