### PR TITLE
If there is no upstream tag default build version to 0

### DIFF
--- a/.github/actions/update-version/update-version.sh
+++ b/.github/actions/update-version/update-version.sh
@@ -12,7 +12,8 @@ git checkout ${VERSION_BRANCH}
 
 source common/autoconf/version-numbers
 MINOR=${JDK_UPDATE_VERSION}
-BUILD=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep "jdk8u${MINOR}" |grep -vE "(-ga|{})$" |cut -d'-' -f2 |tr -d 'b' |sort -nr |head -n1 || echo "0")
+BUILD=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep "jdk8u${MINOR}" |grep -vE "(-ga|{})$" |cut -d'-' -f2 |tr -d 'b' |sort -nr |head -n1)
+BUILD=${BUILD:-"0"}
 MAJOR=8
 CURRENT_VERSION=$(cat version.txt)
 

--- a/.github/actions/update-version/update-version.sh
+++ b/.github/actions/update-version/update-version.sh
@@ -12,7 +12,7 @@ git checkout ${VERSION_BRANCH}
 
 source common/autoconf/version-numbers
 MINOR=${JDK_UPDATE_VERSION}
-BUILD=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep "jdk8u${MINOR}" |grep -vE "(-ga|{})$" |cut -d'-' -f2 |tr -d 'b' |sort -nr |head -n1)
+BUILD=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep "jdk8u${MINOR}" |grep -vE "(-ga|{})$" |cut -d'-' -f2 |tr -d 'b' |sort -nr |head -n1 || echo "0")
 MAJOR=8
 CURRENT_VERSION=$(cat version.txt)
 


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description


### Related issues


### Motivation and context


### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
