### PR TITLE
Add Async-Profiler to the third-party notice

### DIFF
--- a/THIRD_PARTY_README
+++ b/THIRD_PARTY_README
@@ -3084,7 +3084,9 @@ included with JRE 8, JDK 8, and OpenJDK 8.
   Apache Santuario XML Security for Java 2.1.3
   Apache Xalan-Java 2.7.2
   Apache Xerces Java 2.7.1
-  Apache XML Resolver 1.1 
+  Apache XML Resolver 1.1
+
+%% Async-Profiler is licensed under Apache 2.0 and may be included as a separate work from the JDK.
 
 
 --- begin of LICENSE ---


### PR DESCRIPTION
### Description

Adding [Async-Profiler](https://github.com/async-profiler/async-profiler/) to the third-party notice: Async-Profiler is licensed under Apache 2.0 and may be included as a separate work from the JDK.

### Motivation and context

Async-Profiler is a low overhead sampling profiler for Java that does not suffer from the Safepoint bias problem. It features HotSpot-specific API to collect stack traces and to track memory allocations. The profiler works with OpenJDK and other Java runtimes based on the HotSpot JVM.

Unlike traditional Java profilers, async-profiler monitors non-Java threads (e.g., GC and JIT compiler threads) and shows native and kernel frames in stack traces.

### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
