### PR TITLE
Using correct output path for mac

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -134,7 +134,7 @@ task prepareArtifacts {
             copy {
                 from project.asyncProfilerBinariesPath
                 include 'bin/**', 'lib/**'
-                into jdkResultingImage
+                into "${jdkResultingImage}/${correttoMacDir}/Contents/Home"
             }
         }
 


### PR DESCRIPTION
Fixing output path for async profiler binaries, follow up to previous PR: https://github.com/corretto/corretto-8/pull/542