### PR TITLE
Defining PRAGMA_DISABLE_GCC_WARNING For Alpine Fastdebug

### DIFF
--- a/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
+++ b/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
@@ -302,6 +302,7 @@ inline int wcslen(const jchar* x) { return wcslen((const wchar_t*)x); }
 #define PRAGMA_FORMAT_NONLITERAL_IGNORED_INTERNAL
 #endif
 
+#define PRAGMA_DISABLE_GCC_WARNING(optstring) _Pragma(STR(GCC diagnostic ignored optstring))
 // Disable -Wstringop-overflow which is introduced in GCC 10.
 // https://gcc.gnu.org/gcc-10/changes.html
 #if !defined(__clang_major__) && (__GNUC__ >= 10)

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -38,7 +38,7 @@ ext {
     }
 }
 
-def jdkResultingImage = "$buildRoot/build/linux-${arch}-normal-server-release/images/j2sdk-image"
+def jdkResultingImage = "$buildRoot/build/linux-${arch}-normal-server-${correttoDebugLevel}/images/j2sdk-image"
 def binaryResultName = "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}"
 def archiveName = "amazon-corretto-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
 def debugArchiveName = "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"


### PR DESCRIPTION
Adding logic to define `PRAGMA_DISABLE_GCC_WARNING` if undefined, pulling logic from opensource upstream tip [here](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/compilerWarnings_gcc.hpp#L37). 

Confirmed that with this change, fastdebug builds work on generic linux and alpine platforms.