### PR TITLE
8257709: C1: Double assignment in InstructionPrinter::print_stack

### DIFF
--- a/hotspot/src/share/vm/c1/c1_InstructionPrinter.cpp
+++ b/hotspot/src/share/vm/c1/c1_InstructionPrinter.cpp
@@ -246,7 +246,7 @@ void InstructionPrinter::print_stack(ValueStack* stack) {
     output()->cr();
     fill_to(start_position, ' ');
     output()->print("locks [");
-    for (int i = i = 0; i < stack->locks_size(); i++) {
+    for (int i = 0; i < stack->locks_size(); i++) {
       Value t = stack->lock_at(i);
       if (i > 0) output()->print(", ");
       output()->print("%d:", i);


### PR DESCRIPTION
Clean backport of https://github.com/openjdk/jdk/pull/1519
also opened pr to upstream but we want AL builds to be passed earlier https://github.com/openjdk/jdk8u-dev/pull/718