### PR TITLE
Remove external freetype requirement for building on Mac and Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,14 +122,7 @@ allprojects {
                 throw new RuntimeException("Invalid corretto.debug_level")
         }
 
-        def freetypeIncludePath = project.findProperty("corretto.freetype_include")
-        def freetypeLibPath = project.findProperty("corretto.freetype_lib")
         def jnfFrameworkPath = project.findProperty("corretto.jnf_path")
-
-        // If freetype location is specified, pass to configure
-        if (freetypeIncludePath && freetypeLibPath) {
-            correttoCommonFlags += ["--with-freetype-include=${freetypeIncludePath}", "--with-freetype-lib=${freetypeLibPath}"]
-        }
 
         // If JNF location is specified, pass to configure
         if (jnfFrameworkPath) {

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -170,23 +170,6 @@ task prepareArtifacts {
             commandLine "SetFile", "-a", "B", "${buildDir}/${correttoMacDir}"
         }
 
-        // Fix freetype linking and permissions
-        def freetypeLibPath = project.findProperty("corretto.freetype_lib")
-        if (freetypeLibPath) {
-            exec {
-                workingDir "${buildDir}/${correttoMacDir}/Contents/Home"
-                commandLine "chmod", "755", "./jre/lib/libfreetype.dylib.6"
-            }
-            exec {
-                workingDir "${buildDir}/${correttoMacDir}/Contents/Home"
-                commandLine "install_name_tool", "-change", "${freetypeLibPath}/libfreetype.6.dylib", "@rpath/libfreetype.dylib.6", "./jre/lib/libfontmanager.dylib"
-            }
-            exec {
-                workingDir "${buildDir}/${correttoMacDir}/Contents/Home"
-                commandLine "install_name_tool", "-id", "@rpath/libfreetype.dylib.6", "./jre/lib/libfreetype.dylib.6"
-            }
-        }
-
         // Include JNF if requested
         def jnfFrameworkPath = project.findProperty("corretto.jnf_path")
         if (jnfFrameworkPath) {

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -11,8 +11,6 @@ bootjdk_dir         # Path of bootstrap JDK. To build Corretto8, JDK7 or JDK8 is
 vcruntime_dir       # Path of the latest msvcr120.dll
 
 msvcp_dir           # Path of the latest msvcp120.dll
-
-freetype_dir        # Path of freetype
 ```
 
 To execute this, run: `./gradlew :installers:windows:zip:build` at `corretto-8` root directory. 
@@ -23,7 +21,6 @@ The zip archives of Corretto8 JDK and JRE are located at `/installers/windows/zi
             -Pbootjdk_dir=... \
             -Pvcruntime_dir=... \
             -Pmsvcp_dir=... \
-            -Pfreetype_dir=...
 ```
 
 Base on the architecture of your system, the execution generates `x64` or `x86` artifacts.

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -54,9 +54,7 @@ task configureBuild(type: Exec) {
     dependsOn copySource
     workingDir "$buildRoot"
     // Platform specific flags
-    def command = ['bash', 'configure',
-            "--with-boot-jdk=${project.getProperty('bootjdk_dir')}",
-            "--with-freetype=${project.getProperty('freetype_dir')}"]
+    def command = ['bash', 'configure', "--with-boot-jdk=${project.getProperty('bootjdk_dir')}"]
     // Common flags
     command += project.correttoCommonFlags
     commandLine command.flatten()


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
The font rendering library, freetype, is now included in OpenJDK source after [JDK-8193017](https://github.com/corretto/corretto-8/commit/335fce5950cdb8f5e2227019ad3a908432654211) was recently backported, removing the requirement of a pre-built freetype for Mac and Windows builds. This commit updates the build logic of those versions to no longer require some properties were previously needed for bundling freetype.

### Related issues

### Motivation and context

### How has this been tested?
Successfully built on MacOS (Ventura) and Windows (Windows Server 2019)

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context

### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
