### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/fetch-dev-repo.yml
+++ b/.github/workflows/fetch-dev-repo.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 8 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
     refresh-jdk8:
         runs-on: ubuntu-latest

--- a/.github/workflows/fetch-repo.yml
+++ b/.github/workflows/fetch-repo.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 7 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
     refresh-jdk8:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.