### PR TITLE
Fix failing java/lang/StrictMath jtreg tests on MacOS 14+ with XCode 15.x

### DIFF
--- a/common/autoconf/flags.m4
+++ b/common/autoconf/flags.m4
@@ -547,7 +547,6 @@ AC_DEFUN_ONCE([FLAGS_SETUP_COMPILER_FLAGS_FOR_JDK],
   # Later we will also have CFLAGS and LDFLAGS for the hotspot subrepo build.
   #
 
-  FDLIBM_CFLAGS=""
   # Setup compiler/platform specific flags to CFLAGS_JDK,
   # CXXFLAGS_JDK and CCXXFLAGS_JDK (common to C and CXX?)
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
@@ -573,7 +572,10 @@ AC_DEFUN_ONCE([FLAGS_SETUP_COMPILER_FLAGS_FOR_JDK],
     FLAGS_COMPILER_CHECK_ARGUMENTS([-Wformat-overflow -Werror],
                                    [USE_FORMAT_OVERFLOW="1"], [USE_FORMAT_OVERFLOW="0"])
     AC_SUBST([USE_FORMAT_OVERFLOW])
+  fi
 
+  FDLIBM_CFLAGS=""
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     # Check that the compiler supports -ffp-contract=off flag
     # Set FDLIBM_CFLAGS to -ffp-contract=off if it does.
     # For GCC < 4.6, on x86, x86_64 and ppc check for
@@ -604,7 +606,11 @@ AC_DEFUN_ONCE([FLAGS_SETUP_COMPILER_FLAGS_FOR_JDK],
     else
       FDLIBM_CFLAGS="$COMPILER_FP_CONTRACT_OFF_FLAG"
     fi
-  elif test "x$TOOLCHAIN_TYPE" = xsolstudio; then
+  fi
+  AC_SUBST(FDLIBM_CFLAGS)
+  AC_MSG_NOTICE([fdlibm will be compiled with flags: $FDLIBM_CFLAGS])
+
+  if test "x$TOOLCHAIN_TYPE" = xsolstudio; then
     CCXXFLAGS_JDK="$CCXXFLAGS $CCXXFLAGS_JDK -DTRACING -DMACRO_MEMSYS_OPS -DBREAKPTS"
     if test "x$OPENJDK_TARGET_CPU_ARCH" = xx86; then
       CCXXFLAGS_JDK="$CCXXFLAGS_JDK -DcpuIntel -Di586 -D$OPENJDK_TARGET_CPU_LEGACY_LIB"
@@ -635,7 +641,6 @@ AC_DEFUN_ONCE([FLAGS_SETUP_COMPILER_FLAGS_FOR_JDK],
           -D_STATIC_CPPLIB -D_DISABLE_DEPRECATE_STATIC_CPPLIB"
     fi
   fi
-  AC_SUBST(FDLIBM_CFLAGS)
 
   ###############################################################################
 

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4455,7 +4455,7 @@ VS_TOOLSET_SUPPORTED_2022=true
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1766720598
+DATE_WHEN_GENERATED=1766807883
 
 ###############################################################################
 #
@@ -42981,7 +42981,6 @@ fi
   # Later we will also have CFLAGS and LDFLAGS for the hotspot subrepo build.
   #
 
-  FDLIBM_CFLAGS=""
   # Setup compiler/platform specific flags to CFLAGS_JDK,
   # CXXFLAGS_JDK and CCXXFLAGS_JDK (common to C and CXX?)
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
@@ -43315,7 +43314,10 @@ $as_echo "$supports" >&6; }
   fi
 
 
+  fi
 
+  FDLIBM_CFLAGS=""
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     # Check that the compiler supports -ffp-contract=off flag
     # Set FDLIBM_CFLAGS to -ffp-contract=off if it does.
     # For GCC < 4.6, on x86, x86_64 and ppc check for
@@ -43457,7 +43459,12 @@ $as_echo "$supports" >&6; }
     else
       FDLIBM_CFLAGS="$COMPILER_FP_CONTRACT_OFF_FLAG"
     fi
-  elif test "x$TOOLCHAIN_TYPE" = xsolstudio; then
+  fi
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: fdlibm will be compiled with flags: $FDLIBM_CFLAGS" >&5
+$as_echo "$as_me: fdlibm will be compiled with flags: $FDLIBM_CFLAGS" >&6;}
+
+  if test "x$TOOLCHAIN_TYPE" = xsolstudio; then
     CCXXFLAGS_JDK="$CCXXFLAGS $CCXXFLAGS_JDK -DTRACING -DMACRO_MEMSYS_OPS -DBREAKPTS"
     if test "x$OPENJDK_TARGET_CPU_ARCH" = xx86; then
       CCXXFLAGS_JDK="$CCXXFLAGS_JDK -DcpuIntel -Di586 -D$OPENJDK_TARGET_CPU_LEGACY_LIB"
@@ -43488,7 +43495,6 @@ $as_echo "$supports" >&6; }
           -D_STATIC_CPPLIB -D_DISABLE_DEPRECATE_STATIC_CPPLIB"
     fi
   fi
-
 
   ###############################################################################
 

--- a/jdk/make/lib/CoreLibraries.gmk
+++ b/jdk/make/lib/CoreLibraries.gmk
@@ -75,7 +75,7 @@ else
       OUTPUT_DIR := $(JDK_OUTPUTDIR)/objs/libfdlibm, \
       SRC := $(JDK_TOPDIR)/src/share/native/java/lang/fdlibm/src, \
       LANG := C, \
-      CFLAGS := $(CFLAGS_JDKLIB) \
+      CFLAGS := $(CFLAGS_JDKLIB) $(LIBFDLIBM_CFLAGS) \
           -I$(JDK_TOPDIR)/src/share/native/java/lang/fdlibm/include, \
       LDFLAGS := -nostdlib -r, \
       OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libfdlibm, \


### PR DESCRIPTION
### Description
Fix failing java/lang/StrictMath jtreg tests when jdk is compiled on MacOS 14+ with XCode 15.x.
Set FDLIBM_CFLAGS to `-ffp-contract=off` for clang (not only gcc) and pass it to fdlibm on MacOS.

The tests started failing when JDK is compiled on Sonoma with Xcode 15, because unlike version 13.4, the default FP contraction mode now permits forming fused multiply-add (FMA) within expressions. This breaks StrictMath tests. We already have FMA disabled for gcc using `-ffp-contract=off`, so we just need to do the same for clang and make sure that it is passed to fdlibm files during compilation.

### How has this been tested?
Building JDK on MacOS Sonoma (14) with XCode 15.4 and running jtreg tests.

I was able to track down the breaking change to XCode version: 14.2 doesn't generate FMA by default, while 14.3.1 does