### PR TITLE
Fix merge issue between corretto patch and JDK-8074840

### DIFF
--- a/jdk/src/share/bin/splashscreen_stubs.c
+++ b/jdk/src/share/bin/splashscreen_stubs.c
@@ -60,12 +60,12 @@ typedef char* (*SplashGetScaledImageName_t)(const char* fileName,
 #define INVOKE(name,def) _INVOKE(name,def,return)
 #define INVOKEV(name) _INVOKE(name, ,;)
 
-int     DoSplashLoadMemory(void* pdata, int size) {
-    INVOKE(SplashLoadMemory, 0)(pdata, size);
+void     DoSplashLoadMemory(void* pdata, int size) {
+    INVOKEV(SplashLoadMemory)(pdata, size);
 }
 
-int     DoSplashLoadFile(const char* filename) {
-    INVOKE(SplashLoadFile, 0)(filename);
+void     DoSplashLoadFile(const char* filename) {
+    INVOKEV(SplashLoadFile)(filename);
 }
 
 void    DoSplashInit(void) {


### PR DESCRIPTION
[This merge](https://github.com/corretto/corretto-8/commit/f65787a11dcaf608fa6541c89520624224fcac38)  into nightly from upstream-dev pulled in [8074840: Resolve disabled warnings for libjli and libjli_static](https://github.com/openjdk/jdk8u-dev/commit/34af1ab36798710f526a6c67a77aa42af4400a1b#diff-77ff9399b296d0becde48bb0675d19acda53735d3cee6ebd3667873f30419730). However, it interferes with [this Corretto patch](https://github.com/corretto/corretto-8/blame/develop/jdk/src/share/bin/splashscreen_stubs.c#L63-L69), causing all nightly builds to fail due to mismatched types. 

The upstream commit addresses multiple warnings in different files, but [the warning addressed](https://github.com/openjdk/jdk8u-dev/pull/733#issue-3707622817) in this file does not occur in the version with our patch, so I preferred keeping the corretto patch in this file, the rest of the commit is OK.

Builds successfully with changes on Macos, Windows, and Linux.
