### PR TITLE
Fixing empty dirs for Windows debug symbols

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -106,6 +106,7 @@ task copyImages() {
         copy {
             from "$imagesDir/j2sdk-image"
             include '**/*.diz'
+            includeEmptyDirs = false
             into "$packagingDir/jdk-symbols"
         }
     }


### PR DESCRIPTION
Adjusting build logic for windows debug symbols to avoid empty directories in output. Tested build to confirm correct behavior.