### PR TITLE
merge upstream-jdk8u-dev

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1354,7 +1354,7 @@ jobs:
 
   macos_x64_build:
     name: macOS x64
-    runs-on: "macos-13"
+    runs-on: "macos-15-intel"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_macos_x64 != 'false'
 
@@ -1421,7 +1421,7 @@ jobs:
         run: brew install make gawk
 
       - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
 
       # Remove once JDK-8376511 has been completed
       - name: Checkout the Apple Openjdk
@@ -1471,7 +1471,7 @@ jobs:
 
   macos_x64_test:
     name: macOS x64
-    runs-on: "macos-13"
+    runs-on: "macos-15-intel"
     needs:
       - prerequisites
       - macos_x64_build
@@ -1560,7 +1560,7 @@ jobs:
         run: brew install make gawk
 
       - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Run tests
         run: >

--- a/common/autoconf/flags.m4
+++ b/common/autoconf/flags.m4
@@ -366,20 +366,6 @@ AC_DEFUN_ONCE([FLAGS_SETUP_COMPILER_FLAGS_FOR_OPTIMIZATION],
         C_O_FLAG_NORM="-O2"
         C_O_FLAG_NONE="-O0"
       fi
-    elif test "x$TOOLCHAIN_TYPE" = xclang; then
-      if test "x$OPENJDK_TARGET_OS" = xmacosx; then
-        # On MacOSX we optimize for size, something
-        # we should do for all platforms?
-        C_O_FLAG_HIGHEST="-Os"
-        C_O_FLAG_HI="-Os"
-        C_O_FLAG_NORM="-Os"
-        C_O_FLAG_NONE=""
-      else
-        C_O_FLAG_HIGHEST="-O3"
-        C_O_FLAG_HI="-O3"
-        C_O_FLAG_NORM="-O2"
-        C_O_FLAG_NONE="-O0"
-      fi
     elif test "x$TOOLCHAIN_TYPE" = xxlc; then
       C_O_FLAG_HIGHEST="-O3"
       C_O_FLAG_HI="-O3 -qstrict"

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4454,7 +4454,7 @@ VS_TOOLSET_SUPPORTED_2022=true
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1770070493
+DATE_WHEN_GENERATED=1770252118
 
 ###############################################################################
 #
@@ -42744,20 +42744,6 @@ $as_echo "$ac_cv_c_bigendian" >&6; }
     # The remaining toolchains share opt flags between CC and CXX;
     # setup for C and duplicate afterwards.
     if test "x$TOOLCHAIN_TYPE" = xgcc -o "x$TOOLCHAIN_TYPE" = xclang; then
-      if test "x$OPENJDK_TARGET_OS" = xmacosx; then
-        # On MacOSX we optimize for size, something
-        # we should do for all platforms?
-        C_O_FLAG_HIGHEST="-Os"
-        C_O_FLAG_HI="-Os"
-        C_O_FLAG_NORM="-Os"
-        C_O_FLAG_NONE=""
-      else
-        C_O_FLAG_HIGHEST="-O3"
-        C_O_FLAG_HI="-O3"
-        C_O_FLAG_NORM="-O2"
-        C_O_FLAG_NONE="-O0"
-      fi
-    elif test "x$TOOLCHAIN_TYPE" = xclang; then
       if test "x$OPENJDK_TARGET_OS" = xmacosx; then
         # On MacOSX we optimize for size, something
         # we should do for all platforms?

--- a/hotspot/make/bsd/makefiles/gcc.make
+++ b/hotspot/make/bsd/makefiles/gcc.make
@@ -19,7 +19,7 @@
 # Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 # or visit www.oracle.com if you need additional information or have any
 # questions.
-#  
+#
 #
 
 OS_VENDOR = $(shell uname -s)
@@ -80,7 +80,7 @@ ifeq ($(SPEC),)
     HOSTCC  = $(CC)
   endif
 
-  AS   = $(CC) -c 
+  AS   = $(CC) -c
 endif
 
 ifeq ($(OS_VENDOR), Darwin)
@@ -112,29 +112,29 @@ ifeq ($(USE_CLANG), true)
     # Clang produces an error if the PCH file was compiled with other options than the actual compilation unit.
     USE_PRECOMPILED_HEADER=0
   endif
-  
+
   ifeq ($(USE_PRECOMPILED_HEADER),1)
-  
+
     ifndef LP64
       $(error " Precompiled Headers only supported on 64-bit platforms!")
     endif
-  
+
     PRECOMPILED_HEADER_DIR=.
     PRECOMPILED_HEADER_SRC=$(GAMMADIR)/src/share/vm/precompiled/precompiled.hpp
     PRECOMPILED_HEADER=$(PRECOMPILED_HEADER_DIR)/precompiled.hpp.pch
-  
+
     PCH_FLAG = -include precompiled.hpp
     PCH_FLAG/DEFAULT = $(PCH_FLAG)
     PCH_FLAG/NO_PCH = -DNO_PCH
     PCH_FLAG/BY_FILE = $(PCH_FLAG/$@)$(PCH_FLAG/DEFAULT$(PCH_FLAG/$@))
-  
+
     VM_PCH_FLAG/LIBJVM = $(PCH_FLAG/BY_FILE)
     VM_PCH_FLAG/AOUT =
     VM_PCH_FLAG = $(VM_PCH_FLAG/$(LINK_INTO))
-  
+
     # We only use precompiled headers for the JVM build
     CFLAGS += $(VM_PCH_FLAG)
- 
+
     # The following files are compiled at various optimization
     # levels due to optimization issues encountered at the
     # 'OPT_CFLAGS_DEFAULT' level. The Clang compiler issues a compile
@@ -150,7 +150,7 @@ ifeq ($(USE_CLANG), true)
     PCH_FLAG/sharedRuntimeTrans.o = $(PCH_FLAG/NO_PCH)
     PCH_FLAG/unsafe.o = $(PCH_FLAG/NO_PCH)
     PCH_FLAG/metaspaceShared.o = $(PCH_FLAG/NO_PCH)
-  
+
   endif
 else # ($(USE_CLANG), true)
   # check for precompiled headers support
@@ -274,7 +274,7 @@ endif
 
 CFLAGS_WARN/DEFAULT = $(WARNINGS_ARE_ERRORS) $(WARNING_FLAGS)
 # Special cases
-CFLAGS_WARN/BYFILE = $(CFLAGS_WARN/$@)$(CFLAGS_WARN/DEFAULT$(CFLAGS_WARN/$@)) 
+CFLAGS_WARN/BYFILE = $(CFLAGS_WARN/$@)$(CFLAGS_WARN/DEFAULT$(CFLAGS_WARN/$@))
 # XXXDARWIN: for _dyld_bind_fully_image_containing_address
 ifeq ($(OS_VENDOR), Darwin)
   CFLAGS_WARN/os_bsd.o = $(CFLAGS_WARN/DEFAULT) -Wno-deprecated-declarations
@@ -315,7 +315,7 @@ OPT_CFLAGS/NOOPT=-O0
 
 # Work around some compiler bugs.
 ifeq ($(USE_CLANG), true)
-  # Known to fail with clang <= 7.0; 
+  # Known to fail with clang <= 7.0;
   # do no optimize these on later clang until verified
   OPT_CFLAGS/loopTransform.o += $(OPT_CFLAGS/NOOPT)
   OPT_CFLAGS/unsafe.o += -O1
@@ -340,7 +340,7 @@ CFLAGS += -DDONT_USE_PRECOMPILED_HEADER
 endif
 
 ifeq ($(OS_VENDOR), Darwin)
-  # Setting these parameters makes it an error to link to macosx APIs that are 
+  # Setting these parameters makes it an error to link to macosx APIs that are
   # newer than the given OS version and makes the linked binaries compatible even
   # if built on a newer version of the OS.
   # The expected format is X.Y.Z
@@ -348,10 +348,10 @@ ifeq ($(OS_VENDOR), Darwin)
     MACOSX_VERSION_MIN=11.00.00
   endif
   # The macro takes the version with no dots, ex: 1070
-  CFLAGS += -DMAC_OS_X_VERSION_MIN_REQUIRED=$(subst .,,$(MACOSX_VERSION_MIN)) \
-            -DMAC_OS_X_VERSION_MAX_ALLOWED=$(subst .,,$(MACOSX_VERSION_MIN)) \
-            -mmacosx-version-min=$(MACOSX_VERSION_MIN)
-  LFLAGS += -mmacosx-version-min=$(MACOSX_VERSION_MIN)
+  MAC_FLAGS = -mmacosx-version-min=$(MACOSX_VERSION_MIN)
+  CFLAGS += -DMAC_OS_X_VERSION_MAX_ALLOWED=$(subst .,,$(MACOSX_VERSION_MIN)) \
+            $(MAC_FLAGS)
+  LFLAGS += $(MAC_FLAGS)
 endif
 
 
@@ -449,7 +449,7 @@ else
   ifeq ($(DEBUG_CFLAGS/$(BUILDARCH)),)
   DEBUG_CFLAGS += -gstabs
   endif
-  
+
   ifeq ($(ENABLE_FULL_DEBUG_SYMBOLS),1)
     FASTDEBUG_CFLAGS/ia64  = -g
     FASTDEBUG_CFLAGS/amd64 = -g
@@ -464,7 +464,7 @@ else
         FASTDEBUG_CFLAGS += -gstabs
       endif
     endif
-  
+
     OPT_CFLAGS/ia64  = -g
     OPT_CFLAGS/amd64 = -g
     OPT_CFLAGS/arm   = -g

--- a/hotspot/make/bsd/makefiles/jsig.make
+++ b/hotspot/make/bsd/makefiles/jsig.make
@@ -54,9 +54,9 @@ LIBJSIG_MAPFILE = $(MAKEFILES_DIR)/mapfile-vers-jsig
 
 LFLAGS_JSIG += -D_GNU_SOURCE -pthread $(LDFLAGS_HASH_STYLE) $(EXTRA_LDFLAGS)
 
-ifeq ($(OS_VENDOR), Darwin)
 # bring in minimum version argument or we'll fail on OSX 10.10
-LFLAGS_JSIG += $(LFLAGS)
+ifeq ($(OS_VENDOR), Darwin)
+  LFLAGS_JSIG += $(MAC_FLAGS)
 endif
 
 # DEBUG_BINARIES overrides everything, use full -g debug information

--- a/hotspot/make/bsd/makefiles/saproc.make
+++ b/hotspot/make/bsd/makefiles/saproc.make
@@ -111,10 +111,10 @@ endif
 
 
 ifneq ($(OS_VENDOR), Darwin)
-SA_LFLAGS = $(MAPFLAG:FILENAME=$(SAMAPFILE))
+  SA_LFLAGS = $(MAPFLAG:FILENAME=$(SAMAPFILE))
 else
-# bring in minimum version argument or we'll fail on OSX 10.10
-SA_LFLAGS = $(LFLAGS)
+  # bring in minimum version argument or we'll fail on OSX 10.10
+  SA_LFLAGS = $(MAC_FLAGS)
 endif
 SA_LFLAGS += $(LDFLAGS_HASH_STYLE) $(EXTRA_LDFLAGS)
 

--- a/jdk/test/com/sun/jndi/ldap/LdapDnsProviderTest.java
+++ b/jdk/test/com/sun/jndi/ldap/LdapDnsProviderTest.java
@@ -104,6 +104,13 @@ class ProviderTest implements Callable<Boolean> {
             env.put(Context.PROVIDER_URL, url);
         }
 
+        // Set JNDI LDAP connect timeout property. It helps to prevent
+        // initial bind operation from blocking in case of a local process
+        // listening on the port specified in the URL. With the property set,
+        // the bind operation will fail with timeout exception, and then it
+        // could be retried with another port number.
+        env.put("com.sun.jndi.ldap.connect.timeout", "1000");
+
         try {
             ctx = new InitialDirContext(env);
             SearchControls scl = new SearchControls();
@@ -112,8 +119,13 @@ class ProviderTest implements Callable<Boolean> {
                     "ou=People,o=Test", "(objectClass=*)", scl);
             throw new RuntimeException("Search should not complete");
         } catch (NamingException e) {
-            e.printStackTrace();
             passed = e.toString().contains(expected);
+            System.err.println((passed ? "Expected" : "Unexpected") +
+                    " NamingException observed: " + e.toString());
+            // Print stack trace only for unexpected exceptions
+            if (!passed) {
+                e.printStackTrace();
+            }
         } finally {
             shutItDown(ctx);
         }
@@ -207,7 +219,7 @@ public class LdapDnsProviderTest {
                     new ProviderTest(url, expected));
         new Thread(future).start();
 
-        System.err.println("Testing: " + url + ", " + expected);
+        System.err.printf("Testing: url='%s', expected content='%s'%n", url, expected);
         while (!future.isDone()) {
             try {
                 if (!future.get()) {

--- a/jdk/test/java/net/BindException/Test.java
+++ b/jdk/test/java/net/BindException/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  /*
  * @test
  * @bug 4417734
+ * @key intermittent
  * @summary Test that we get a BindException in all expected combinations
  */
 import java.net.*;

--- a/jdk/test/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/jdk/test/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,6 +108,23 @@ public class TestDockerMemoryMetrics {
 
     private static void testMemoryFailCount(String value) throws Exception {
         Common.logNewTestCase("testMemoryFailCount" + value);
+
+        // Check whether swapping really works for this test
+        // On some systems there is no swap space enabled. And running
+        // 'java -Xms{mem-limit} -Xmx{mem-limit} -version' would fail due to swap space size being 0.
+        DockerRunOptions preOpts =
+                new DockerRunOptions(imageName, "/jdk/bin/java", "-version");
+        preOpts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/")
+                .addDockerOpts("--memory=" + value)
+                .addJavaOpts("-Xms" + value)
+                .addJavaOpts("-Xmx" + value);
+        OutputAnalyzer oa = DockerTestUtils.dockerRunJava(preOpts);
+        String output = oa.getOutput();
+        if (!output.contains("version")) {
+            System.out.println("Swapping doesn't work for this test.");
+            return;
+        }
+
         DockerRunOptions opts =
                 new DockerRunOptions(imageName, "/jdk/bin/java", "MetricsMemoryTester");
         opts.addDockerOpts("--volume", Utils.TEST_CLASSES + ":/test-classes/")
@@ -115,7 +132,13 @@ public class TestDockerMemoryMetrics {
                 .addJavaOpts("-Xmx" + value)
                 .addJavaOpts("-cp", "/test-classes/")
                 .addClassOptions("failcount");
-        DockerTestUtils.dockerRunJava(opts).shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
+        oa = DockerTestUtils.dockerRunJava(opts);
+        output = oa.getOutput();
+        if (output.contains("Ignoring test")) {
+            System.out.println("Ignored by the tester");
+            return;
+        }
+        oa.shouldHaveExitValue(0).shouldContain("TEST PASSED!!!");
     }
 
     private static void testMemoryAndSwapLimit(String memory, String memandswap) throws Exception {


### PR DESCRIPTION
This PR merges the latest changes from upstream jdk8u-dev into corretto-8.

### Merge Conflicts Resolved

1. common/autoconf/flags.m4
A merge conflict in con/autoconf/flags.m4 was actually fixed in the [recent PR](https://github.com/corretto/corretto-8/pull/564). However, the upstream merge reintroduced conflicts in this area that required resolution in this PR.

2. hotspot/make/bsd/makefiles/gcc.make
This file had a conflict between two corretto patches: [one](https://github.com/corretto/corretto-8/commit/24de76f6be59ccd76f4cb2837e252b1efc4671b7#diff-3279351a84cc06256736b58f16531cb7f2d25df7a0d776ec52789b04a5e5eca5), [two](https://github.com/corretto/corretto-8/commit/f167bb36ab6e0ba843eea0434d6cb0d435c548b6) and [a recent commit from upstream-dev](https://github.com/corretto/corretto-8/commit/08e617e725bf285e93d75a2a3b37fc6b5010bc5egit ).

Rest of the files were merged automatically.