### PR TITLE
8380689: distrust/Chunghwa.java test fails with a compilation error

### DIFF
--- a/jdk/test/sun/security/ssl/X509TrustManagerImpl/distrust/Chunghwa.java
+++ b/jdk/test/sun/security/ssl/X509TrustManagerImpl/distrust/Chunghwa.java
@@ -34,7 +34,7 @@ import java.util.Date;
  * @bug 8369282
  * @summary Check that TLS Server certificates chaining back to distrusted
  *          Chunghwa root are invalid
- * @library /test/lib
+ * @library /lib/security
  * @modules java.base/sun.security.validator
  * @run main/othervm Chunghwa after policyOn invalid
  * @run main/othervm Chunghwa after policyOff valid


### PR DESCRIPTION
Pulling in test change for https://bugs.openjdk.org/browse/JDK-8380689 early. 

Risk is minimal: one liner that only alters this one test