### PR TITLE
Fixing debug symbol artifact name for Windows

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -141,7 +141,7 @@ task packageDebugSymbols(type: Exec) {
     dependsOn copyVersionInfo
     outputs.dir(distributionDir)
     distributionDir.mkdirs()
-    def archiveName = file("$distributionDir/unsigned-jdk-debugsymbols-image.${project.correttoArch}.zip")
+    def archiveName = file("${distributionDir}/${project.correttoDebugSymbolsArchiveName}.zip")
     workingDir "$packagingDir/jdk-symbols"
     commandLine 'bash', '-c', "zip -qr \$(cygpath -u \'$archiveName\') *"
     artifacts.add('archives', archiveName)


### PR DESCRIPTION
Using `correttoDebugSymbolsArchiveName` for debug symbols name, as is done with mac and linux builds. 

First looked to backport change from Corretto 11, but the `build.gradle` had diverged significantly.

Confirmed build succeeds.