### PR TITLE
8252250: isnanf is obsolete

### DIFF
--- a/jdk/src/solaris/native/common/jdk_util_md.h
+++ b/jdk/src/solaris/native/common/jdk_util_md.h
@@ -37,7 +37,7 @@
 #define ISNAND(d) isnan(d)
 #elif defined(__linux__) || defined(_ALLBSD_SOURCE)
 #include <math.h>
-#define ISNANF(f) isnanf(f)
+#define ISNANF(f) isnan(f)
 #define ISNAND(d) isnan(d)
 #elif defined(_AIX)
 #include <math.h>


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8252250

Reviewed-by: vkempik
Backport-of: b957d802e6982be56d3a344668d8fd230f20d0df

Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK 8
and is not specific to Corretto 8,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto 8,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Upstream backport has been submitted and  waiting for an approval.

### Related issues


### Motivation and context


### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "build 1.8.0_192-amazon-corretto-preview-b12" (output from "java -version")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
