### PR TITLE
Backporting JDK-8305825 and JDK-8386991

### DIFF
--- a/jdk/src/solaris/classes/sun/awt/X11/XDecoratedPeer.java
+++ b/jdk/src/solaris/classes/sun/awt/X11/XDecoratedPeer.java
@@ -306,7 +306,19 @@ abstract class XDecoratedPeer extends XWindowPeer {
             || ev.get_atom() == XWM.XA_NET_FRAME_EXTENTS.getAtom())
         {
             if (XWM.getWMID() != XWM.UNITY_COMPIZ_WM) {
-                getWMSetInsets(XAtom.get(ev.get_atom()));
+                if (XWM.getWMID() == XWM.MUTTER_WM && !isTargetUndecorated() && isVisible()) {
+                    // Insets might have changed "in-flight" if that property
+                    // is present, so we need to get the actual values of
+                    // insets from the WM and propagate them through all the
+                    // proper channels.
+                    wm_set_insets = null;
+                    Insets in = getWMSetInsets(XAtom.get(ev.get_atom()));
+                    if (in != null && !in.equals(dimensions.getInsets())) {
+                        handleCorrectInsets(in);
+                    }
+                } else {
+                    getWMSetInsets(XAtom.get(ev.get_atom()));
+                }
             } else {
                 if(!isReparented()) {
                     return;

--- a/jdk/src/solaris/classes/sun/awt/X11/XWM.java
+++ b/jdk/src/solaris/classes/sun/awt/X11/XWM.java
@@ -1352,6 +1352,9 @@ final class XWM
               case UNITY_COMPIZ_WM:
                   res = new Insets(28, 1, 1, 1);
                   break;
+              case MUTTER_WM:
+                  res = new Insets(37, 0, 0, 0);
+                  break;
               case MOTIF_WM:
               case OPENLOOK_WM:
               default:
@@ -1363,6 +1366,7 @@ final class XWM
         }
         return res;
     }
+
     /*
      * Some buggy WMs ignore window gravity when processing
      * ConfigureRequest and position window as if the gravity is Static.

--- a/jdk/test/ProblemList.txt
+++ b/jdk/test/ProblemList.txt
@@ -117,6 +117,7 @@
 
 # 8221305
 java/awt/FontMetrics/MaxAdvanceIsMax.java             solaris-all,macosx-all
+java/awt/KeyboardFocusmanager/ConsumeNextMnemonicKeyTypedTest/ConsumeNextMnemonicKeyTypedTest.java 8321303 linux-all
 
 ############################################################################
 

--- a/jdk/test/java/awt/Focus/OwnedWindowFocusIMECrashTest/OwnedWindowFocusIMECrashTest.java
+++ b/jdk/test/java/awt/Focus/OwnedWindowFocusIMECrashTest/OwnedWindowFocusIMECrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,6 +64,7 @@ public class OwnedWindowFocusIMECrashTest {
         window.setVisible(true);
 
         Util.waitForIdle(robot);
+        robot.delay(1000);
 
         test();
 

--- a/jdk/test/java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java
+++ b/jdk/test/java/awt/SplashScreen/MultiResolutionSplash/MultiResolutionSplashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,6 +119,7 @@ public class MultiResolutionSplashTest {
 
         System.out.println("Focus Test!");
         Robot robot = new Robot();
+        robot.setAutoWaitForIdle(true);
         robot.setAutoDelay(50);
 
         Frame frame = new Frame();
@@ -129,6 +130,7 @@ public class MultiResolutionSplashTest {
         frame.add(textField);
         frame.setVisible(true);
         robot.waitForIdle();
+        robot.delay(1000);
 
         robot.keyPress(KeyEvent.VK_A);
         robot.keyRelease(KeyEvent.VK_A);


### PR DESCRIPTION
Backporting "8386991: Insets are incorrectly set in newer Gnome versions" and "8305825: getBounds API returns wrong value resulting in multiple Regression Test Failures on Ubuntu 23.04". Patch is mostly clean (skipping some test files that are not in 8).

The original backport of [JDK-8305825](https://bugs.openjdk.org/browse/JDK-8305825) missed changes to src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java for JDK 17 and below. For 21 and above, JDK-8305825 reuses an [if statement](https://github.com/azvegint/jdk/blob/f2210a19f2364324c8e3636e740325f93b19701d/src/java.desktop/unix/classes/sun/awt/X11/XDecoratedPeer.java#L344-L354) introduced by [JDK-8267307](https://bugs.openjdk.org/browse/JDK-8267307). For 17 and below, since JDK-8267307 wasn't backported/present, a similar if statement should have been added just without the JDK-8267307-specific condition.

This leads to the SimpleTest.java test included on that JBS issue continuing to fail on Ubuntu 24.04 without this fix.

This patch adds in the relevant code from the original JDK-8305825 patch to ensure the test passes and windows are rendered with the correct insets and size.